### PR TITLE
Add issue marker for rdf:JSON datatype.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1139,7 +1139,7 @@
     <h3>The <code>rdf:JSON</code> Datatype</h3>
 
     <p class="issue" data-number="14">
-      The `rdf:JSON`datatype  is originally defined in
+      The `rdf:JSON` datatype is originally defined in
       <a data-cite="?JSON-LD11#the-rdf-json-datatype">Section 10.2 The `rdf:JSON` Datatype</a>
       in [[?JSON-LD11]].
     </p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1135,6 +1135,16 @@
       in RDF/XML [[RDF12-XML]].</p>
   </section>
 
+  <section id="section-json" class="informative">
+    <h3>The <code>rdf:JSON</code> Datatype</h3>
+
+    <p class="issue" data-number="14">
+      The `rdf:JSON`datatype  is originally defined in
+      <a data-cite="?JSON-LD11#the-rdf-json-datatype">Section 10.2 The `rdf:JSON` Datatype</a>
+      in [[?JSON-LD11]].
+    </p>
+  </section>
+
   <section>
     <h3>Datatype IRIs</h3>
 


### PR DESCRIPTION
The `rdf:JSON` datatype is originally defined in  <a href="https://w3.org/TR/JSON-LD11/#the-rdf-json-datatype">Section 10.2 The `rdf:JSON` Datatype</a>  in [JSON-LD 1.1](https://w3.org/TR/JSON-LD11/). This issue is to promote the definition to RDF Concepts (and RDF Schema) to keep it with the definition of other datatypes in the RDF namespace.

See also https://github.com/w3c/rdf-schema/issues/7.

For #14.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/18.html" title="Last updated on Mar 16, 2023, 7:01 PM UTC (b1a5e7d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/18/e93ecf0...b1a5e7d.html" title="Last updated on Mar 16, 2023, 7:01 PM UTC (b1a5e7d)">Diff</a>