### PR TITLE
add note about rdf:PlainLiteral

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -852,6 +852,9 @@
     The list of datatypes supported by an implementation is determined
     by its <a>recognized datatype IRIs</a>.</p>
 
+  <p class="note"><code>rdf:PlainLiteral</code> [[RDF-plain-literal]] is no longer used in RDF 
+    itself, but that it continues to be part of RIF [[RIF-RDF-OWL]] and OWL2 [[OWL2-mapping-to-RDF]].</p>
+
   <p>A <dfn>datatype</dfn> consists of a <a>lexical space</a>,
     a <a>value space</a> and a <a>lexical-to-value mapping</a>, and
     is denoted by one or more <a>IRIs</a>.</p>


### PR DESCRIPTION
`rdf:PlainLiteral` is no longer used in RDF. It is still available at http://www.w3.org/1999/02/22-rdf-syntax-ns#
see https://github.com/w3c/rdf-star-wg/issues/52


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/33.html" title="Last updated on Apr 16, 2023, 1:32 PM UTC (7e81b58)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/33/9a3cf20...7e81b58.html" title="Last updated on Apr 16, 2023, 1:32 PM UTC (7e81b58)">Diff</a>