### PR TITLE
Note about "blank node label"

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -781,7 +781,7 @@
 
       <p>The term "blank node label" is sometimes used informally
       as an alternative to the term <a>blank node identifier</a>.
-      This alternative has also been used in earlier versions of
+      This alternative was also used in earlier versions of
       some RDF-related specifications such as [[SPARQL11-QUERY]].
       In the interest of consistency, the use of this alternative
       term is discouraged now.</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -763,8 +763,8 @@
       the set of possible blank nodes is arbitrary.  RDF makes no reference to
       any internal structure of blank nodes.</p>
 
-    <p class="note" id="note-bnode-id">
-      <span id="dfn-blank-node-identifiers"><!-- obsolete term--></span><dfn data-lt="blank node identifier">Blank node identifiers</dfn>
+    <div class="note" id="note-bnode-id">
+      <p><span id="dfn-blank-node-identifiers"><!-- obsolete term--></span><dfn data-lt="blank node identifier">Blank node identifiers</dfn>
       are local identifiers that are used in some
       <a>concrete RDF syntaxes</a>
       or RDF store implementations.
@@ -778,6 +778,14 @@
       identifiers in concrete syntaxes need to be careful not to create the
       same blank node from multiple occurrences of the same blank node identifier
       except in situations where this is supported by the syntax.</p>
+
+      <p>The term "blank node label" is sometimes used informally
+      as an alternative to the term <a>blank node identifier</a>.
+      This alternative has also been used in earlier versions of
+      some RDF-related specifications such as [[SPARQL11-QUERY]].
+      In the interest of consistency, the use of this alternative
+      term is discouraged now.</p>
+    </div>
   </section>
 
   <section id="section-skolemization">


### PR DESCRIPTION
As considered in #38, this PR extends the note in Section 3.4 (Blank Nodes) to mention that the term "blank node label" is sometimes used as an alternative to the term "blank node identifier". I have also included a sentences stating that the use of this alternative is discouraged now.

Fixes #38.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/39.html" title="Last updated on May 9, 2023, 9:08 PM UTC (2b1c808)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/39/90bca44...2b1c808.html" title="Last updated on May 9, 2023, 9:08 PM UTC (2b1c808)">Diff</a>