### PR TITLE
IRI terminology

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -478,7 +478,7 @@
       many different ways to encode the same <a>RDF graph</a> or
       <a>RDF dataset</a>, for example through the use of
       <a>namespace prefixes</a>,
-      <a>relative IRIs</a>, <a>blank node identifiers</a>,
+      <a>relative IRI references</a>, <a>blank node identifiers</a>,
       and different ordering of statements. While these aspects can have great
       effect on the convenience of working with the <a>RDF document</a>,
       they are not significant for its meaning.</p>
@@ -599,8 +599,8 @@
     <p class="note">For convenience, a complete [[ABNF]] grammar
       from [[RFC3987]] is provided in <a href="#iri-abnf" class="sectionRef"></a>.</p>
 
-    <p>IRIs in the RDF abstract syntax MUST be absolute, and MAY
-      contain a fragment identifier.</p>
+    <p>IRIs in the RDF abstract syntax MUST be absolute,
+      and MAY contain a fragment identifier.</p>
 
     <p><dfn>IRI equality</dfn>:
       Two IRIs are equal if and only if they are <a>equivalent</a>
@@ -609,16 +609,13 @@
       of [[!RFC3987]]. Further normalization MUST NOT be performed when
       comparing IRIs for equality.</p>
 
-      <p class="issue" data-number="15">
-        The group is updating IRI terminology to more closer follow the current RFCs.
-      </p>
-
     <div class="note" id="note-iris">
       <p><strong>URIs and IRIs:</strong>
         IRIs are a generalization of
         <dfn data-lt="URI" data-lt-noDefault><abbr title="Uniform Resource Identifier">URI</abbr>s</dfn>
         [[RFC3986]] that permits a wider range of Unicode characters.
         Every absolute URI and URL is an IRI, but not every IRI is an URI.
+        In RDF, IRIs are used as <em>IRI references</em>, as defined in [[RFC3987]].
         When IRIs are used in operations that are only
         defined for URIs, they must first be converted according to
         the mapping defined in
@@ -628,13 +625,15 @@
         characters, %-encoding of octets not allowed in URIs, and
         Punycode-encoding of domain names.</p>
 
-      <p><strong>Relative IRIs:</strong>
+      <p><strong>Relative IRI references:</strong>
         Some <a>concrete RDF syntaxes</a> permit
-        <span id="dfn-relative-iris"><!-- obsolete term--></span><dfn data-lt="relative iri">relative IRIs</dfn> as a convenient shorthand
+        <span id="dfn-relative-iris"><!-- obsolete term--></span>
+        <dfn data-lt="relative iri reference">relative IRI references</dfn> as a convenient shorthand
         that allows authoring of documents independently from their final
-        publishing location. Relative IRIs must be
-        <a data-cite="rfc3986#section-5.2">resolved
-        against</a> a <dfn class="export">base IRI</dfn> to make them absolute.
+        publishing location.
+        Relative IRI references must be
+        <a data-cite="rfc3986#section-5.2">resolved against</a> a
+        <dfn class="export">base IRI</dfn> to make them absolute.
         Therefore, the RDF graph serialized in such syntaxes is well-defined only
         if a <a data-cite="rfc3986#section-5.1">base IRI
         can be established</a> [[RFC3986]].</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -625,6 +625,15 @@
         characters, %-encoding of octets not allowed in URIs, and
         Punycode-encoding of domain names.</p>
 
+      <p><strong>URLs:</strong>
+        The [[[URL]]] is largely compatible with [[RFC3987]] IRIs,
+        but is based on a processing model important for implementation
+        within Web browers and cannot be easily described using an [[ABNF]] grammar.
+        Additionally, URLs are processed,
+        for example, by replacing percent-encoded characters with their unencoded values.
+        Within RDF, IRIs are unprocessed.
+      </p>
+
       <p><strong>Relative IRI references:</strong>
         Some <a>concrete RDF syntaxes</a> permit
         <span id="dfn-relative-iris"><!-- obsolete term--></span>

--- a/spec/index.html
+++ b/spec/index.html
@@ -628,10 +628,7 @@
       <p><strong>URLs:</strong>
         The [[[URL]]] is largely compatible with [[RFC3987]] IRIs,
         but is based on a processing model important for implementation
-        within Web browers and cannot be easily described using an [[ABNF]] grammar.
-        Additionally, URLs are processed,
-        for example, by replacing percent-encoded characters with their unencoded values.
-        Within RDF, IRIs are unprocessed.
+        within web browsers and are not described using an [[ABNF]] grammar.
       </p>
 
       <p><strong>Relative IRI references:</strong>


### PR DESCRIPTION
* Update language about relative IRI references for Erratum 29.
* Describe the differences between URLs and IRIs.

Fixes #15.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on May 10, 2023, 6:55 PM UTC)_.

<details>
<summary>More</summary>







_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/rdf-concepts%2341.)._
</details>
