### PR TITLE
Fixes the anchor for "Relative IRI Reference" 

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1068,7 +1068,7 @@
       information.</p>
 
     <table class="simple">
-      <caption>A list of the RDF-compatible XSD types, with short descriptions"</caption>
+      <caption>A list of the RDF-compatible XSD types, with short descriptions</caption>
       <tr><th></th><th>Datatype</th><th>Value space (informative)</th></tr>
 
       <tr><th rowspan="4">Core types</th><td><a data-cite="xmlschema11-2#string"><code>xsd:string</code></a></td><td>Character strings (but not all Unicode character strings)</td></tr>

--- a/spec/index.html
+++ b/spec/index.html
@@ -309,7 +309,7 @@
       Some namespace IRIs are associated by convention with a short name
       known as a <dfn>namespace prefix</dfn>. Some examples:
 
-    <table class="simple">
+    <table id="tab-vocab-ns" class="simple">
       <caption>Some example namespace prefixes and IRIs</caption>
       <tr>
         <th>Namespace prefix</th>
@@ -1028,7 +1028,7 @@
   <p>The <a>literals</a> that can be defined using this
     datatype are:</p>
 
-  <table class="simple">
+  <table id="tab-boolean-literals" class="simple">
     <caption>This table lists the literals of type xsd:boolean.</caption>
     <tr>
       <th>Literal</th>
@@ -1067,7 +1067,7 @@
       datatypes are the only safe datatypes for transferring binary
       information.</p>
 
-    <table class="simple">
+    <table id="tab-xsd-datatypes" class="simple">
       <caption>A list of the RDF-compatible XSD types, with short descriptions</caption>
       <tr><th></th><th>Datatype</th><th>Value space (informative)</th></tr>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -634,7 +634,7 @@
       <p><strong>Relative IRI references:</strong>
         Some <a>concrete RDF syntaxes</a> permit
         <span id="dfn-relative-iris"><!-- obsolete term--></span>
-        <dfn data-lt="relative iri reference">relative IRI references</dfn> as a convenient shorthand
+        <dfn id="dfn-relative-iri" data-lt="relative iri reference">relative IRI references</dfn> as a convenient shorthand
         that allows authoring of documents independently from their final
         publishing location.
         Relative IRI references must be


### PR DESCRIPTION
which should be `dfn-relative-iri`, not `dfn-relative-iri-reference`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/42.html" title="Last updated on May 18, 2023, 3:56 PM UTC (1d77b80)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/42/ccb9227...1d77b80.html" title="Last updated on May 18, 2023, 3:56 PM UTC (1d77b80)">Diff</a>