### PR TITLE
Adds note about limitations of xsd:float and xsd:double

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1156,15 +1156,15 @@
       of <a data-cite="xmlschema11-2#double"><code>xsd:double</code></a> and
       <a data-cite="xmlschema11-2#float"><code>xsd:float</code></a> do not
       include all decimal numbers. For every literal of
-      any of these two datatypes, the value
+      either of these two datatypes, the value
       of the literal is a value that can be represented as an
       <a href="http://ieeexplore.ieee.org/servlet/opac?punumber=4610933">IEEE 754-2008</a>
       binary floating point representation of the corresponding precision.
       For instance, the literal with
       lexical form `"0.1"` and datatype <a data-cite="xmlschema11-2#float"><code>xsd:float</code></a>
-      <a>denotes</a> the number 0.100000001490116119384765625.
-      As an alternative to <a data-cite="xmlschema11-2#double"><code>xsd:double</code></a>
-      and <a data-cite="xmlschema11-2#float"><code>xsd:float</code></a>, the
+      <a>denotes</a> the number `0.100000001490116119384765625`.
+      Rather than <a data-cite="xmlschema11-2#double"><code>xsd:double</code></a>
+      or <a data-cite="xmlschema11-2#float"><code>xsd:float</code></a>, the
       datatype <a data-cite="xmlschema11-2#decimal"><code>xsd:decimal</code></a>
       can be used to accurately capture arbitrary decimal numbers.</p>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -1161,9 +1161,9 @@
       <a href="http://ieeexplore.ieee.org/servlet/opac?punumber=4610933">IEEE 754-2008</a>
       binary floating point representation of the corresponding precision.
       As a consequence, not all decimal numbers are accurately captured by
-      using these two datatypes. For instance, the value of the literal with
-      lexical value `"0.1"` and datatype <a data-cite="xmlschema11-2#float"><code>xsd:float</code></a>
-      is rounded to the floating point number 0.100000001490116119384765625.
+      using these two datatypes. For instance, the literal with
+      lexical form `"0.1"` and datatype <a data-cite="xmlschema11-2#float"><code>xsd:float</code></a>
+      <a>denotes</a> the number 0.100000001490116119384765625.
       As an alternative to <a data-cite="xmlschema11-2#double"><code>xsd:double</code></a>
       and <a data-cite="xmlschema11-2#float"><code>xsd:float</code></a>, the
       datatype <a data-cite="xmlschema11-2#decimal"><code>xsd:decimal</code></a>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1084,8 +1084,8 @@
       <tr><td><a data-cite="xmlschema11-2#integer"><code>xsd:integer</code></a></td><td>Arbitrary-size integer numbers</td></tr>
 
       <tr><th rowspan="2">IEEE floating-point<br />numbers</th>
-          <td><a data-cite="xmlschema11-2#double"><code>xsd:double</code></a></td><td>64-bit floating point numbers incl. ±Inf, ±0, NaN</td></tr>
-      <tr><td><a data-cite="xmlschema11-2#float"><code>xsd:float</code></a></td><td>32-bit floating point numbers incl. ±Inf, ±0, NaN</td></tr>
+          <td><a data-cite="xmlschema11-2#double"><code>xsd:double</code></a></td><td>64-bit floating point numbers incl. ±Inf, ±0, NaN (note that this does <em>not</em> include all decimal numbers)</td></tr>
+      <tr><td><a data-cite="xmlschema11-2#float"><code>xsd:float</code></a></td><td>32-bit floating point numbers incl. ±Inf, ±0, NaN (note that this does <em>not</em> include all decimal numbers)</td></tr>
 
       <tr><th rowspan="4">Time and date</th>
           <td><a data-cite="xmlschema11-2#date"><code>xsd:date</code></a></td><td>Dates (yyyy-mm-dd) with or without timezone</td></tr>
@@ -1151,6 +1151,23 @@
         are sequence-valued datatypes which do not fit the RDF <a>datatype</a>
         model.</li>
     </ul>
+
+    <p class="note">As mentioned in the table above, the <a>value spaces</a>
+      of <a data-cite="xmlschema11-2#double"><code>xsd:double</code></a> and
+      <a data-cite="xmlschema11-2#float"><code>xsd:float</code></a> do not
+      include all decimal numbers. The reason is that, for every literal of
+      any of these two datatypes, the value given as the <a>lexical form</a>
+      of the literal is rounded to a value that can be represented as an
+      <a href="http://ieeexplore.ieee.org/servlet/opac?punumber=4610933">IEEE 754-2008</a>
+      binary floating point representation of the corresponding precision.
+      As a consequence, many decimal numbers are not accurately captured by
+      using these two datatypes. For instance, the value of the literal with
+      lexical value `"0.1"` and datatype <a data-cite="xmlschema11-2#float"><code>xsd:float</code></a>
+      is rounded to the floating point number 0.100000001490116119384765625.
+      As an alternative to <a data-cite="xmlschema11-2#double"><code>xsd:double</code></a>
+      and <a data-cite="xmlschema11-2#float"><code>xsd:float</code></a>, the
+      datatype <a data-cite="xmlschema11-2#decimal"><code>xsd:decimal</code></a>
+      can be used to accurately capture arbitrary decimal numbers.</p>
 
   </section>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -1160,8 +1160,7 @@
       of the literal is a value that can be represented as an
       <a href="http://ieeexplore.ieee.org/servlet/opac?punumber=4610933">IEEE 754-2008</a>
       binary floating point representation of the corresponding precision.
-      As a consequence, not all decimal numbers are accurately captured by
-      using these two datatypes. For instance, the literal with
+      For instance, the literal with
       lexical form `"0.1"` and datatype <a data-cite="xmlschema11-2#float"><code>xsd:float</code></a>
       <a>denotes</a> the number 0.100000001490116119384765625.
       As an alternative to <a data-cite="xmlschema11-2#double"><code>xsd:double</code></a>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1084,8 +1084,8 @@
       <tr><td><a data-cite="xmlschema11-2#integer"><code>xsd:integer</code></a></td><td>Arbitrary-size integer numbers</td></tr>
 
       <tr><th rowspan="2">IEEE floating-point<br />numbers</th>
-          <td><a data-cite="xmlschema11-2#double"><code>xsd:double</code></a></td><td>64-bit floating point numbers incl. ±Inf, ±0, NaN (note that this does <em>not</em> include all decimal numbers)</td></tr>
-      <tr><td><a data-cite="xmlschema11-2#float"><code>xsd:float</code></a></td><td>32-bit floating point numbers incl. ±Inf, ±0, NaN (note that this does <em>not</em> include all decimal numbers)</td></tr>
+          <td><a data-cite="xmlschema11-2#double"><code>xsd:double</code></a></td><td>64-bit floating point numbers incl. ±Inf, ±0, NaN</td></tr>
+      <tr><td><a data-cite="xmlschema11-2#float"><code>xsd:float</code></a></td><td>32-bit floating point numbers incl. ±Inf, ±0, NaN</td></tr>
 
       <tr><th rowspan="4">Time and date</th>
           <td><a data-cite="xmlschema11-2#date"><code>xsd:date</code></a></td><td>Dates (yyyy-mm-dd) with or without timezone</td></tr>
@@ -1152,7 +1152,7 @@
         model.</li>
     </ul>
 
-    <p class="note">As mentioned in the table above, the <a>value spaces</a>
+    <p class="note">The <a>value spaces</a>
       of <a data-cite="xmlschema11-2#double"><code>xsd:double</code></a> and
       <a data-cite="xmlschema11-2#float"><code>xsd:float</code></a> do not
       include all decimal numbers. The reason is that, for every literal of
@@ -1160,7 +1160,7 @@
       of the literal is rounded to a value that can be represented as an
       <a href="http://ieeexplore.ieee.org/servlet/opac?punumber=4610933">IEEE 754-2008</a>
       binary floating point representation of the corresponding precision.
-      As a consequence, many decimal numbers are not accurately captured by
+      As a consequence, not all decimal numbers are accurately captured by
       using these two datatypes. For instance, the value of the literal with
       lexical value `"0.1"` and datatype <a data-cite="xmlschema11-2#float"><code>xsd:float</code></a>
       is rounded to the floating point number 0.100000001490116119384765625.

--- a/spec/index.html
+++ b/spec/index.html
@@ -1156,8 +1156,8 @@
       of <a data-cite="xmlschema11-2#double"><code>xsd:double</code></a> and
       <a data-cite="xmlschema11-2#float"><code>xsd:float</code></a> do not
       include all decimal numbers. For every literal of
-      any of these two datatypes, the value given as the <a>lexical form</a>
-      of the literal is rounded to a value that can be represented as an
+      any of these two datatypes, the value
+      of the literal is a value that can be represented as an
       <a href="http://ieeexplore.ieee.org/servlet/opac?punumber=4610933">IEEE 754-2008</a>
       binary floating point representation of the corresponding precision.
       As a consequence, not all decimal numbers are accurately captured by

--- a/spec/index.html
+++ b/spec/index.html
@@ -1155,7 +1155,7 @@
     <p class="note">The <a>value spaces</a>
       of <a data-cite="xmlschema11-2#double"><code>xsd:double</code></a> and
       <a data-cite="xmlschema11-2#float"><code>xsd:float</code></a> do not
-      include all decimal numbers. The reason is that, for every literal of
+      include all decimal numbers. For every literal of
       any of these two datatypes, the value given as the <a>lexical form</a>
       of the literal is rounded to a value that can be represented as an
       <a href="http://ieeexplore.ieee.org/servlet/opac?punumber=4610933">IEEE 754-2008</a>


### PR DESCRIPTION
... as suggested by @jmkeil in #43


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/44.html" title="Last updated on Jun 8, 2023, 4:18 PM UTC (9734f13)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/44/d310888...9734f13.html" title="Last updated on Jun 8, 2023, 4:18 PM UTC (9734f13)">Diff</a>