### PR TITLE
Add base direction as a fourth element of literals.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -74,7 +74,7 @@
 
   <p>RDF 1.2 introduces <a>quoted triples</a> as another kind of <a>RDF term</a>
     which can be used as the <a>subject</a> or <a>object</a> of another <a>triple</a>.
-    RDF 1.2 also introduces a <a>text direction</a> element to <a>language-tagged strings</a>,
+    RDF 1.2 also introduces a <a>base text direction</a> element to <a>directional language-tagged strings</a>,
     allowing the initial text direction to be specified when
     presented in a user agent.</p>
 
@@ -698,7 +698,7 @@
       case.
       The fourth element, <a>text direction</a> MUST NOT be
       present unless the <a>language tag</a> element is present.
-      The value space of <a>text direction</a> is either empty, or one of `ltr` or `rtl`.</p>
+      The value space of <a>base text direction</a> is either empty, or one of `ltr` or `rtl`.</p>
 
     <p>Please note that concrete syntaxes MAY support
       <dfn data-lt="simple literal" class="export">simple literals</dfn> consisting of only a
@@ -717,8 +717,10 @@
 
     <ol>
       <li>If the literal is a <a>language-tagged string</a>,
-        then the literal value is a tuple consisting of its <a>lexical form</a>,
-        its <a>language tag</a>, and its <a>text direction</a>, in that order.</li>
+        then the literal value is a pair consisting of its <a>lexical form</a>
+        and its <a>language tag</a>, in that order.</li>
+      <li>if the literal is a <a>directional language string</a>, then the literal value is
+      a tuple of its <a>lexical form</a>, its <a>language tag</a>, and its <a>base text direction</a>, likewise in that order.</li>
 
       <li>If the literal's <a>datatype IRI</a> is in the set of
         <a>recognized datatype IRIs</a>, let <var>d</var> be the
@@ -764,20 +766,20 @@
     <section id="section-text-direction" class="informative">
       <h3>Text Direction</h3>
 
-      <p>The <a>text direction</a> of a <a>language-tagged string</a>
-        provides means of establishing the initial direction of text,
+      <p>The <a>base text direction</a> of a <a>directional language string</a>
+        provides a means of establishing the initial direction of text,
         including text which is mixture of right-to-left and left-to-right scripts.
         The [[[?UAX9]]] [[?UAX9]] provides support for automatically rendering
         a sequence of characters in logical order,
         so that they are visually ordered as expected.
         However, this is not sufficient to correctly render bidirectional text.</p>
 
-      <p>For example, the text `"פעילות הבינאום, W3C"` with language tag "he" may be displayed
-        incorrectly unless the <a>text direction</a> of `rtl` (for right-to-left)
+      <p>For example, the text `"פעילות הבינאום, W3C"` with language tag "he" (for Hebrew) may be displayed
+        incorrectly unless the <a>base text direction</a> of `rtl` (for right-to-left)
         is also provided.
         When this is provided to a user agent,
         for example using the HTML `dir` attribute,
-        this would be correctly presented as <br/><span lang="he" dir="rtl">פעילות הבינאום, W3C</span>.</p>
+        it would be correctly presented as <br/><span lang="he" dir="rtl">פעילות הבינאום, W3C</span>.</p>
     </section>
   </section>
 
@@ -1667,7 +1669,7 @@
       for informative definition of a <a>quad</a>.</li>
     <li>Added <a href="#section-quoted-triples" class="sectionRef"></a>
       and definitions for <a>quoted triple</a> and <a>asserted triple</a>.</li>
-    <li>Added the <a>text direction</a> element as part of 
+    <li>Added the <a>base text direction</a> element as part of 
       a <a>literal</a>,
       and a description of its use in <a href="#section-text-direction" class="sectionRef"></a>.</li>
   </ul>

--- a/spec/index.html
+++ b/spec/index.html
@@ -757,9 +757,10 @@
     <p><dfn data-local-lt="term-equal">Literal term equality</dfn>:
       Two literals are term-equal (the same <a>RDF literal</a>)
       if and only if the two <a>lexical forms</a>,
-      the two <a>datatype IRIs</a> compare equal, character by character,
-      the two <a>language tags</a> (if any) compare equal, as if normalized to lower case, and
-      the two <a>base directions</a> (if any) compare equal, character by character.
+      the two <a>datatype IRIs</a>,
+      the two <a>language tags</a> (if any) normalized to lower case, and
+      the two <a>base directions</a> (if any),
+      all compare equal, character by character.
       Thus, two literals can have the same value
       without being the same <a>RDF term</a>.
       For example:</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -33,7 +33,7 @@
         { name: "Brian McBride" }
       ],
 
-      xref: ["i18n-glossary", "infra"],
+      xref: ["I18N-GLOSSARY", "INFRA"],
       github: "https://github.com/w3c/rdf-concepts/",
       group:           "rdf-star",
       doJsonLd:     true,
@@ -510,10 +510,10 @@
       Within this, and related specifications, the term <dfn id="dfn-rdf-string">string</dfn>,
       or <a data-lt="string">RDF string</a>,
       is used to describe an ordered sequence of zero or more
-      <a data-cite="i18n-glossary#dfn-code-point" class="lint-ignore">Unicode code points</a>
-      which are <a data-cite="i18n-glossary#dfn-scalar-value" class="lint-ignore">Unicode scalar values</a>.
+      <a data-cite="I18N-GLOSSARY#dfn-code-point" class="lint-ignore">Unicode code points</a>
+      which are <a data-cite="I18N-GLOSSARY#dfn-scalar-value" class="lint-ignore">Unicode scalar values</a>.
       Unicode scalar values do not include the
-      <a data-cite="i18n-glossary#dfn-surrogate" class="lint-ignore">surrogate code points</a>.
+      <a data-cite="I18N-GLOSSARY#dfn-surrogate" class="lint-ignore">surrogate code points</a>.
       Note that most <a>concrete RDF syntaxes</a> require the use
       of the UTF-8 character encoding [[!RFC3629]], 
       and use the `\u0000` or `\U00000000` forms to express certain non-character values.
@@ -521,10 +521,10 @@
 
     <p>A string is identical to another string if it consists of the same sequence of code points.
       An implementation MAY determine string equality by comparing the
-      <a data-cite="i18n-glossary#dfn-code-unit">code units</a> of two strings
-      that use the same <a data-cite="i18n-glossary#dfn-character-encoding">Unicode character encoding</a>
+      <a data-cite="I18N-GLOSSARY#dfn-code-unit">code units</a> of two strings
+      that use the same <a data-cite="I18N-GLOSSARY#dfn-character-encoding">Unicode character encoding</a>
       (UTF-8 or UTF-16) without decoding the string into a
-      <a data-cite="i18n-glossary#dfn-code-point" class="lint-ignore">Unicode code point</a> sequence.</p>
+      <a data-cite="I18N-GLOSSARY#dfn-code-point" class="lint-ignore">Unicode code point</a> sequence.</p>
   </section>
 </section>
 
@@ -619,7 +619,7 @@
 
     <p><dfn>IRI equality</dfn>:
       Two IRIs are the same if and only if they consist of the same sequence of
-      <a data-cite="i18n-glossary#dfn-code-point" class="lint-ignore">Unicode code points</a>,
+      <a data-cite="I18N-GLOSSARY#dfn-code-point" class="lint-ignore">Unicode code points</a>,
       as in Simple String Comparison in
       <a data-cite="rfc3987#section-5.3.1">section 5.3.1</a> of [[!RFC3987]].
       (This is done in the abstract syntax, so the IRIs are resolved
@@ -705,10 +705,10 @@
 
     <ul>
       <li>a <dfn>lexical form</dfn> consisting of a sequence of
-        <a data-cite="i18n-glossary#dfn-code-point" class="lint-ignore">Unicode code points</a> [[!UNICODE]]
-        which are <a data-cite="i18n-glossary#dfn-scalar-value">Unicode scalar values</a>,
+        <a data-cite="I18N-GLOSSARY#dfn-code-point" class="lint-ignore">Unicode code points</a> [[!UNICODE]]
+        which are <a data-cite="I18N-GLOSSARY#dfn-scalar-value">Unicode scalar values</a>,
         and therefore do not contain
-        <a data-cite="i18n-glossary#dfn-surrogate" class="lint-ignore">Unicode surrogate code points</a>.</li>
+        <a data-cite="I18N-GLOSSARY#dfn-surrogate" class="lint-ignore">Unicode surrogate code points</a>.</li>
       <li>a <dfn>datatype IRI</dfn>, being an <a>IRI</a>
         identifying a datatype that determines how the lexical form maps
         to a <a>literal value</a>, and</li>
@@ -788,7 +788,7 @@
       the two <a>datatype IRIs</a>,
       the two <a>language tags</a> (if any), and
       the two <a>base directions</a> (if any) compare equal,
-      using <a data-cite="i18n-glossary#dfn-case-sensitive">case sensitive matching</a>
+      using <a data-cite="I18N-GLOSSARY#dfn-case-sensitive">case sensitive matching</a>
       (see description of string comparison in <a href="#rdf-strings" class="sectionRef"></a>).
       Thus, two literals can have the same value
       without being the same <a>RDF term</a>.
@@ -1805,7 +1805,7 @@
       from <a data-cite="?JSON-LD11#the-rdf-json-datatype">Section&nbsp;10.2 The `rdf:JSON` Datatype</a>
       in [[?JSON-LD11]].</li>
     <li>Clarify Unicode terminology,
-      using <a data-cite="i18n-glossary#dfn-code-point" class="lint-ignore">Unicode code points</a>,
+      using <a data-cite="I18N-GLOSSARY#dfn-code-point" class="lint-ignore">Unicode code points</a>,
       and restriction to the XML <a data-cite="XML11#charsets">Char</a> production.
       Also removes obsolete recommendations for the use of Normalization Form C in literals.
       Adds a definition of <a>string</a> that can be used in other RDF documents.</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -675,7 +675,7 @@
     <p>Literals are used for values such as strings, numbers, and dates.</p>
 
     <p>A <dfn data-local-lt="RDF literal">literal</dfn> in an <a>RDF graph</a> consists of
-      two to four elements:</p>
+      two, three, or four elements:</p>
 
     <ul>
       <li>a <dfn>lexical form</dfn>, being a Unicode [[!UNICODE]] string,

--- a/spec/index.html
+++ b/spec/index.html
@@ -74,7 +74,7 @@
 
   <p>RDF 1.2 introduces <a>quoted triples</a> as another kind of <a>RDF term</a>
     which can be used as the <a>subject</a> or <a>object</a> of another <a>triple</a>.
-    RDF 1.2 also introduces a <a>base text direction</a> element to <a>language-tagged strings</a>,
+    RDF 1.2 also introduces a <a>base direction</a> element to <a>language-tagged strings</a>,
     allowing the initial text direction to be specified when
     presented in a user agent.</p>
 
@@ -689,16 +689,16 @@
         of [[!BCP47]].</li>
       <li>if and only if the <a>datatype IRI</a> is
         <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#langString</code>,
-        <dfn>base text direction</dfn> MUST be empty, `ltr` or `rtl`.</li>
+        <dfn>base direction</dfn> MUST be empty, `ltr` or `rtl`.</li>
     </ul>
 
     <p>A literal is a <dfn>language-tagged string</dfn> if the third element
       is present. Lexical representations of language tags MAY be converted
       to lower case. The value space of language tags is always in lower
       case.
-      The fourth element, <a>base text direction</a> MUST NOT be
+      The fourth element, <a>base direction</a> MUST NOT be
       present unless the <a>language tag</a> element is present.
-      The value space of <a>base text direction</a> is either empty, or one of `ltr` or `rtl`.</p>
+      The value space of <a>base direction</a> is either empty, or one of `ltr` or `rtl`.</p>
 
     <p>Please note that concrete syntaxes MAY support
       <dfn data-lt="simple literal" class="export">simple literals</dfn> consisting of only a
@@ -720,7 +720,7 @@
         then the literal value is a pair consisting of its <a>lexical form</a>
         and its <a>language tag</a>, in that order.</li>
       <li>if the literal is a <a>language-tagged string</a>, then the literal value is
-      a tuple of its <a>lexical form</a>, its <a>language tag</a>, and its <a>base text direction</a>, likewise in that order.</li>
+      a tuple of its <a>lexical form</a>, its <a>language tag</a>, and its <a>base direction</a>, likewise in that order.</li>
 
       <li>If the literal's <a>datatype IRI</a> is in the set of
         <a>recognized datatype IRIs</a>, let <var>d</var> be the
@@ -748,7 +748,7 @@
       if and only if the two <a>lexical forms</a>,
       the two <a>datatype IRIs</a>,
       the two <a>language tags</a> (if any), and
-      the two <a>base text directions</a> (if any)
+      the two <a>base directions</a> (if any)
       compare equal, character by character.
       Thus, two literals can have the same value
       without being the same <a>RDF term</a>. For example:</p>
@@ -764,9 +764,9 @@
       <a>lexical form</a> differs.</p>
 
     <section id="section-text-direction" class="informative">
-      <h3>Text Direction</h3>
+      <h3>Initial Text Direction</h3>
 
-      <p>The <a>base text direction</a> of a <a>language-tagged string</a>
+      <p>The <a>base direction</a> of a <a>language-tagged string</a>
         provides a means of establishing the initial direction of text,
         including text which is mixture of right-to-left and left-to-right scripts.
         The [[[?UAX9]]] [[?UAX9]] provides support for automatically rendering
@@ -775,11 +775,17 @@
         However, this is not sufficient to correctly render bidirectional text.</p>
 
       <p>For example, the text `"פעילות הבינאום, W3C"` with language tag "he" (for Hebrew) may be displayed
-        incorrectly unless the <a>base text direction</a> of `rtl` (for right-to-left)
+        incorrectly unless the <a>base direction</a> of `rtl` (for right-to-left)
         is also provided.
         When this is provided to a user agent,
         for example using the HTML `dir` attribute,
         it would be correctly presented as <br/><span lang="he" dir="rtl">פעילות הבינאום, W3C</span>.</p>
+
+      <p class="note">The absence of a <a>base direction</a> does not necessarily imply that
+        the text has no initial text direct;
+        as described in [[[?UAX9]]],
+        strings may be embedded within structures which establish an <em>embedding direction</em>,
+        which determines the default bidirectional orientation of text.</p>
     </section>
   </section>
 
@@ -1516,17 +1522,14 @@
 
 <section id="internationalization" class="appendix informative">
   <h2>Internationalization Considerations</h2>
-  <p>RDF is restricted to representing string values with left-to-right or right-to-left direction indicators.
-    RDF provides a mechanism for specifying the language associated with
-    a string (<a>language-tagged string</a>),
-    but does not provide a means of indicating the base direction of the string.</p>
-
   <p>Unicode provides a mechanism for signaling direction within a string
-    (see [[[UAX9]]] [[UAX9]]),
-    however, when a string has an overall base direction which cannot be determined by the
+    (see [[[UAX9]]] [[UAX9]]).
+    RDF provides a machnism for specifying the <a>base direction</a>
+    of a <a>language-tagged string</a>
+    to signal the initial text direction of a string.
+    When a string has an overall base direction which cannot be determined by the
     beginning of the string, an external indicator is required,
-    such as the [[HTML]] <a data-cite="HTML/dom.html#the-dir-attribute">dir attribute</a>,
-    which currently has no counterpart for <a>RDF literals</a>.</p>
+    such as the [[HTML]] <a data-cite="HTML/dom.html#the-dir-attribute">dir attribute</a>.</p>
 
   <p>[[[JSON-LD11]]] [[JSON-LD11]] introduced the
     <a data-cite="JSON-LD11#the-i18n-namespace">i18n namespace</a> to use
@@ -1669,7 +1672,7 @@
       for informative definition of a <a>quad</a>.</li>
     <li>Added <a href="#section-quoted-triples" class="sectionRef"></a>
       and definitions for <a>quoted triple</a> and <a>asserted triple</a>.</li>
-    <li>Added the <a>base text direction</a> element as part of 
+    <li>Added the <a>base direction</a> element as part of 
       a <a>literal</a>,
       and a description of its use in <a href="#section-text-direction" class="sectionRef"></a>.</li>
   </ul>

--- a/spec/index.html
+++ b/spec/index.html
@@ -692,9 +692,9 @@
       <li>if and only if the <a>datatype IRI</a> is
         <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#dirLangString</code>,
         a non-empty <a>language tag</a>
-        MUST be well-formed according to <a data-cite="bcp47#section-2.2.9">section 2.2.9</a>
+        that MUST be well-formed according to <a data-cite="bcp47#section-2.2.9">section 2.2.9</a>
         of [[!BCP47]].
-        and <dfn>base direction</dfn> MUST be either `ltr` or `rtl`.</li>
+        and a <dfn>base direction</dfn> that MUST be either `ltr` or `rtl`.</li>
     </ul>
 
     <p>A literal is a <dfn>language-tagged string</dfn> if the third element
@@ -707,7 +707,7 @@
     <p>A literal is a <dfn id="dfn-dir-lang-string">directional language-tagged string</dfn>
       if both the third element and fourth elements are present.
       Language tags are treated identically to <a>language-tagged string</a>,
-      and the fourth element , <a>base direction</a> MUST BE either `ltr` or `rtl`.</p>
+      and the fourth element , <a>base direction</a> MUST BE either `ltr` or `rtl` in lower case.</p>
 
     <p>Please note that concrete syntaxes MAY support
       <dfn data-lt="simple literal" class="export">simple literals</dfn> consisting of only a
@@ -721,7 +721,7 @@
       <a>language-tagged strings</a> and <a>directional language-tagged strings</a> without
       the <a>datatype IRI</a> because it always equals either
       <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#langString</code> (<code>rdf:langString</code>)
-      or <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#dirLangString</code> (<code>rdf:dirLangString</code>).</p>
+      or <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#dirLangString</code> (<code>rdf:dirLangString</code>), respectively.</p>
 
     <p>The <dfn>literal value</dfn> associated with a <a>literal</a> is:</p>
 
@@ -772,7 +772,7 @@
     <p>denote the same <a data-lt="literal value">value</a>, but are not the
       same literal <a>RDF terms</a> and are not
       <a>term-equal</a> because their
-      <a>lexical form</a> differs.</p>
+      <a>lexical forms</a> differ.</p>
 
     <section id="section-text-direction" class="informative">
       <h3>Initial Text Direction</h3>
@@ -790,10 +790,10 @@
         is also provided.
         When this is provided to a user agent,
         for example using the HTML `dir` attribute,
-        it would be correctly presented as <br/><span lang="he" dir="rtl">פעילות הבינאום, W3C</span>.</p>
+        it would be correctly presented as follows: <div lang="he" dir="rtl">פעילות הבינאום, W3C</div></p>
 
       <p class="note">The absence of a <a>base direction</a> does not necessarily imply that
-        the text has no initial text direct;
+        the text has no initial text direction;
         as described in [[[?UAX9]]],
         strings may be embedded within structures which establish an <em>embedding direction</em>,
         which determines the default bidirectional orientation of text.</p>
@@ -1535,7 +1535,7 @@
   <h2>Internationalization Considerations</h2>
   <p>Unicode provides a mechanism for signaling direction within a string
     (see [[[UAX9]]] [[UAX9]]).
-    RDF provides a machnism for specifying the <a>base direction</a>
+    RDF provides a mechanism for specifying the <a>base direction</a>
     of a <a>directional language-tagged string</a>
     to signal the initial text direction of a string.
     When a string has an overall base direction which cannot be determined by the

--- a/spec/index.html
+++ b/spec/index.html
@@ -74,9 +74,9 @@
 
   <p>RDF 1.2 introduces <a>quoted triples</a> as another kind of <a>RDF term</a>
     which can be used as the <a>subject</a> or <a>object</a> of another <a>triple</a>.
-    RDF 1.2 also introduces a <a>base direction</a> element to <a>language-tagged strings</a>,
-    allowing the initial text direction to be specified when
-    presented in a user agent.</p>
+    RDF 1.2 also introduces <a>directional language-tagged strings</a>
+    containing a <a>base direction</a> element allowing the
+    initial text direction to be specified when presented in a user agent.</p>
 
   <p>RDF 1.2 Concepts introduces key concepts and terminology for RDF 1.2, discusses
     datatyping, and the handling of <a>fragment identifiers</a> in IRIs within
@@ -156,7 +156,9 @@
     <a>datatypes</a> that define the range of possible
     values, such as strings, numbers, and dates. Special kind of literals,
     <a>language-tagged strings</a>, denote
-    plain-text strings in a natural language.</p>
+    plain-text strings in a natural language, and
+    <a>directional language-tagged strings</a>, denote
+    plain-text strings in a natural language and include an initial text direction.</p>
 
     <p>Asserting an <a>RDF triple</a> says that <em>some relationship,
     indicated by the <a>predicate</a>, holds between the
@@ -688,17 +690,24 @@
         <a data-cite="bcp47#section-2.2.9">section 2.2.9</a>
         of [[!BCP47]].</li>
       <li>if and only if the <a>datatype IRI</a> is
-        <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#langString</code>,
-        <dfn>base direction</dfn> MUST be empty, `ltr` or `rtl`.</li>
+        <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#dirLangString</code>,
+        a non-empty <a>language tag</a>
+        MUST be well-formed according to <a data-cite="bcp47#section-2.2.9">section 2.2.9</a>
+        of [[!BCP47]].
+        and <dfn>base direction</dfn> MUST be either `ltr` or `rtl`.</li>
     </ul>
 
     <p>A literal is a <dfn>language-tagged string</dfn> if the third element
-      is present. Lexical representations of language tags MAY be converted
-      to lower case. The value space of language tags is always in lower
-      case.
-      The fourth element, <a>base direction</a> MUST NOT be
-      present unless the <a>language tag</a> element is present.
-      The value space of <a>base direction</a> is either empty, or one of `ltr` or `rtl`.</p>
+      is present and the fourth element is not present.
+      Lexical representations of language tags MAY be converted
+      to lower case or formatted according to  the recommendation for formatting language tags
+      as described in <a data-cite="BCP47#section-2.1.1">section 2.1.1</a> of [[BCP47]].
+      The value of language tags is always treated as being in lower case.</p>
+
+    <p>A literal is a <dfn id="dfn-dir-lang-string">directional language-tagged string</dfn>
+      if both the third element and fourth elements are present.
+      Language tags are treated identically to <a>language-tagged string</a>,
+      and the fourth element , <a>base direction</a> MUST BE either `ltr` or `rtl`.</p>
 
     <p>Please note that concrete syntaxes MAY support
       <dfn data-lt="simple literal" class="export">simple literals</dfn> consisting of only a
@@ -709,9 +718,10 @@
       <code>http://www.w3.org/2001/XMLSchema#string</code>
       (which is commonly abbreviated as <code>xsd:string</code>).
       Similarly, most concrete syntaxes represent
-      <a>language-tagged strings</a> without
-      the <a>datatype IRI</a> because it always equals
-      <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#langString</code> (<code>rdf:langString</code>).</p>
+      <a>language-tagged strings</a> and <a>directional language-tagged strings</a> without
+      the <a>datatype IRI</a> because it always equals either
+      <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#langString</code> (<code>rdf:langString</code>)
+      or <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#dirLangString</code> (<code>rdf:dirLangString</code>).</p>
 
     <p>The <dfn>literal value</dfn> associated with a <a>literal</a> is:</p>
 
@@ -719,8 +729,9 @@
       <li>If the literal is a <a>language-tagged string</a>,
         then the literal value is a pair consisting of its <a>lexical form</a>
         and its <a>language tag</a>, in that order.</li>
-      <li>if the literal is a <a>language-tagged string</a>, then the literal value is
-      a tuple of its <a>lexical form</a>, its <a>language tag</a>, and its <a>base direction</a>, likewise in that order.</li>
+      <li>if the literal is a <a>directional language-tagged string</a>, then the literal value is
+        a tuple of its <a>lexical form</a>, its <a>language tag</a>, and its <a>base direction</a>,
+        likewise in that order.</li>
 
       <li>If the literal's <a>datatype IRI</a> is in the set of
         <a>recognized datatype IRIs</a>, let <var>d</var> be the
@@ -746,12 +757,12 @@
     <p><dfn data-local-lt="term-equal">Literal term equality</dfn>:
       Two literals are term-equal (the same <a>RDF literal</a>)
       if and only if the two <a>lexical forms</a>,
-      the two <a>datatype IRIs</a>,
-      the two <a>language tags</a> (if any), and
-      the two <a>base directions</a> (if any)
-      compare equal, character by character.
+      the two <a>datatype IRIs</a> compare equal, character by character,
+      the two <a>language tags</a> (if any) compare equal, as if normalized to lower case, and
+      the two <a>base directions</a> (if any) compare equal, character by character.
       Thus, two literals can have the same value
-      without being the same <a>RDF term</a>. For example:</p>
+      without being the same <a>RDF term</a>.
+      For example:</p>
 
     <pre>
       `"1"^^xs:integer`
@@ -766,7 +777,7 @@
     <section id="section-text-direction" class="informative">
       <h3>Initial Text Direction</h3>
 
-      <p>The <a>base direction</a> of a <a>language-tagged string</a>
+      <p>The <a>base direction</a> of a <a>directional language-tagged string</a>
         provides a means of establishing the initial direction of text,
         including text which is mixture of right-to-left and left-to-right scripts.
         The [[[?UAX9]]] [[?UAX9]] provides support for automatically rendering
@@ -1525,7 +1536,7 @@
   <p>Unicode provides a mechanism for signaling direction within a string
     (see [[[UAX9]]] [[UAX9]]).
     RDF provides a machnism for specifying the <a>base direction</a>
-    of a <a>language-tagged string</a>
+    of a <a>directional language-tagged string</a>
     to signal the initial text direction of a string.
     When a string has an overall base direction which cannot be determined by the
     beginning of the string, an external indicator is required,

--- a/spec/index.html
+++ b/spec/index.html
@@ -74,7 +74,7 @@
 
   <p>RDF 1.2 introduces <a>quoted triples</a> as another kind of <a>RDF term</a>
     which can be used as the <a>subject</a> or <a>object</a> of another <a>triple</a>.
-    RDF 1.2 also introduces a <a>base text direction</a> element to <a>directional language-tagged strings</a>,
+    RDF 1.2 also introduces a <a>base text direction</a> element to <a>language-tagged strings</a>,
     allowing the initial text direction to be specified when
     presented in a user agent.</p>
 
@@ -689,14 +689,14 @@
         of [[!BCP47]].</li>
       <li>if and only if the <a>datatype IRI</a> is
         <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#langString</code>,
-        <dfn>text direction</dfn> MUST be empty, `ltr` or `rtl`.</li>
+        <dfn>base text direction</dfn> MUST be empty, `ltr` or `rtl`.</li>
     </ul>
 
     <p>A literal is a <dfn>language-tagged string</dfn> if the third element
       is present. Lexical representations of language tags MAY be converted
       to lower case. The value space of language tags is always in lower
       case.
-      The fourth element, <a>text direction</a> MUST NOT be
+      The fourth element, <a>base text direction</a> MUST NOT be
       present unless the <a>language tag</a> element is present.
       The value space of <a>base text direction</a> is either empty, or one of `ltr` or `rtl`.</p>
 
@@ -719,7 +719,7 @@
       <li>If the literal is a <a>language-tagged string</a>,
         then the literal value is a pair consisting of its <a>lexical form</a>
         and its <a>language tag</a>, in that order.</li>
-      <li>if the literal is a <a>directional language string</a>, then the literal value is
+      <li>if the literal is a <a>language-tagged string</a>, then the literal value is
       a tuple of its <a>lexical form</a>, its <a>language tag</a>, and its <a>base text direction</a>, likewise in that order.</li>
 
       <li>If the literal's <a>datatype IRI</a> is in the set of
@@ -748,7 +748,7 @@
       if and only if the two <a>lexical forms</a>,
       the two <a>datatype IRIs</a>,
       the two <a>language tags</a> (if any), and
-      the two <a>text directions</a> (if any)
+      the two <a>base text directions</a> (if any)
       compare equal, character by character.
       Thus, two literals can have the same value
       without being the same <a>RDF term</a>. For example:</p>
@@ -766,7 +766,7 @@
     <section id="section-text-direction" class="informative">
       <h3>Text Direction</h3>
 
-      <p>The <a>base text direction</a> of a <a>directional language string</a>
+      <p>The <a>base text direction</a> of a <a>language-tagged string</a>
         provides a means of establishing the initial direction of text,
         including text which is mixture of right-to-left and left-to-right scripts.
         The [[[?UAX9]]] [[?UAX9]] provides support for automatically rendering

--- a/spec/index.html
+++ b/spec/index.html
@@ -711,7 +711,7 @@
 
     <p>Please note that concrete syntaxes MAY support
       <dfn data-lt="simple literal" class="export">simple literals</dfn> consisting of only a
-      <a>lexical form</a> without any <a>datatype IRI</a> or <a>language tag</a>.
+      <a>lexical form</a> without any <a>datatype IRI</a>, <a>language tag</a>, or <a>base direction</a>.
       Simple literals are syntactic sugar for abstract syntax
       <a>literals</a>
       with the <a>datatype IRI</a>

--- a/spec/index.html
+++ b/spec/index.html
@@ -149,10 +149,9 @@
     <a>literal value</a>. Literals have
     <a>datatypes</a> that define the range of possible
     values, such as strings, numbers, and dates. Special kind of literals,
-    <a>language-tagged strings</a>, denote
-    plain-text strings in a natural language, and
-    <a>directional language-tagged strings</a>, denote
-    plain-text strings in a natural language and include an initial text direction.</p>
+    <a>language-tagged strings</a> and <a>directional language-tagged strings</a>,
+    respectively denote plain-text strings in a natural language, and plain-text
+    strings in a natural language including an initial text direction.</p>
 
     <p>Asserting an <a>RDF triple</a> says that <em>some relationship,
     indicated by the <a>predicate</a>, holds between the
@@ -735,8 +734,8 @@
 
     <p>A literal is a <dfn id="dfn-dir-lang-string">directional language-tagged string</dfn>
       if both the third element and fourth elements are present.
-      Language tags are treated identically to <a>language-tagged string</a>,
-      and the fourth element , <a>base direction</a> MUST BE either `ltr` or `rtl` in lower case.</p>
+      The third element, the language tag, is treated identically as in a <a>language-tagged string</a>,
+      and the fourth element, <a>base direction</a>, MUST be either `ltr` or `rtl`, which MUST be in lower case.</p>
 
     <p>Please note that concrete syntaxes MAY support
       <dfn data-lt="simple literal" class="export">simple literals</dfn> consisting of only a
@@ -810,24 +809,19 @@
 
       <p>The <a>base direction</a> of a <a>directional language-tagged string</a>
         provides a means of establishing the initial direction of text,
-        including text which is mixture of right-to-left and left-to-right scripts.
+        including text which is a mixture of right-to-left and left-to-right scripts.
         The [[[?UAX9]]] [[?UAX9]] provides support for automatically rendering
         a sequence of characters in logical order,
         so that they are visually ordered as expected.
         However, this is not sufficient to correctly render bidirectional text.</p>
 
-      <p>For example, the text `"פעילות הבינאום, W3C"` with language tag "he" (for Hebrew) may be displayed
-        incorrectly unless the <a>base direction</a> of `rtl` (for right-to-left)
-        is also provided.
-        When this is provided to a user agent,
-        for example using the HTML `dir` attribute,
-        it would be correctly presented as follows: <div lang="he" dir="rtl">פעילות הבינאום, W3C</div></p>
-
-      <p class="note">The absence of a <a>base direction</a> does not necessarily imply that
-        the text has no initial text direction;
-        as described in [[[?UAX9]]],
-        strings may be embedded within structures which establish an <em>embedding direction</em>,
-        which determines the default bidirectional orientation of text.</p>
+       <p>For example, some text with a language tag "`he`" might be displayed
+         in a left-to-right context (such as an English web page) as
+         <bdi dir="ltr">פעילות הבינאום, W3C</bdi>, which is incorrect. When provided
+         to a user agent including base direction information (such as using
+         HTML's `dir` attribute) it can then be correctly presented as:
+       </p>
+       <div lang="he" dir="rtl">פעילות הבינאום, W3C</div>
     </section>
   </section>
 
@@ -1645,9 +1639,13 @@
     RDF provides a mechanism for specifying the <a>base direction</a>
     of a <a>directional language-tagged string</a>
     to signal the initial text direction of a string.
-    When a string has an overall base direction which cannot be determined by the
-    beginning of the string, an external indicator is required,
-    such as the [[HTML]] <a data-cite="HTML/dom.html#the-dir-attribute">dir attribute</a>.</p>
+    For most human language strings, but particularly for those
+    whose base direction cannot be accurately determined from the 
+    string content, is it valuable to have an external indicator in order
+    to get the proper display and isolation of the value.
+    One example of such an indicator is
+    the [[HTML]] <a data-cite="HTML/dom.html#the-dir-attribute">dir attribute</a>.
+    see [[STRING-META]].</p>
 
   <p>[[[JSON-LD11]]] [[JSON-LD11]] introduced the
     <a data-cite="JSON-LD11#the-i18n-namespace">i18n namespace</a> to use
@@ -1799,7 +1797,7 @@
       and clarifies that, in the abstract syntax, IRIs are resolved,
       avoiding the incorrect use of "absolute IRI".</li>
     <li>Changed reference from DOM4, which was not a recommendation at the time, to [[DOM]],
-      making the <a>rdf:HTML</a> and <a>rdf:XMLLiteral</a> datatypes normative.</li>
+      making the definitions of <a>rdf:HTML</a> and <a>rdf:XMLLiteral</a> datatypes normative.</li>
     <li>Added <a href="#section-additional-datatypes" class="sectionRef"></a>
       and moved the sections about the <a>rdf:HTML</a> and <a>rdf:XMLLiteral</a>
       datatypes to this appendix.</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -73,7 +73,10 @@
   </ul>
 
   <p>RDF 1.2 introduces <a>quoted triples</a> as another kind of <a>RDF term</a>
-    which can be used as the <a>subject</a> or <a>object</a> of another <a>triple</a>.</p>
+    which can be used as the <a>subject</a> or <a>object</a> of another <a>triple</a>.
+    RDF 1.2 also introduces a <a>text direction</a> element to <a>language-tagged strings</a>,
+    allowing the initial text direction to be specified when
+    presented in a user agent.</p>
 
   <p>RDF 1.2 Concepts introduces key concepts and terminology for RDF 1.2, discusses
     datatyping, and the handling of <a>fragment identifiers</a> in IRIs within
@@ -669,8 +672,8 @@
 
     <p>Literals are used for values such as strings, numbers, and dates.</p>
 
-    <p>A <dfn data-local-lt="RDF literal">literal</dfn> in an <a>RDF graph</a> consists of two or three
-      elements:</p>
+    <p>A <dfn data-local-lt="RDF literal">literal</dfn> in an <a>RDF graph</a> consists of
+      two to four elements:</p>
 
     <ul>
       <li>a <dfn>lexical form</dfn>, being a Unicode [[!UNICODE]] string,
@@ -684,12 +687,18 @@
         language tag MUST be well-formed according to
         <a data-cite="bcp47#section-2.2.9">section 2.2.9</a>
         of [[!BCP47]].</li>
+      <li>if and only if the <a>datatype IRI</a> is
+        <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#langString</code>,
+        <dfn>text direction</dfn> MUST be empty, `ltr` or `rtl`.</li>
     </ul>
 
     <p>A literal is a <dfn>language-tagged string</dfn> if the third element
       is present. Lexical representations of language tags MAY be converted
       to lower case. The value space of language tags is always in lower
-      case.</p>
+      case.
+      The fourth element, <a>text direction</a> MUST NOT be
+      present unless the <a>language tag</a> element is present.
+      The value space of <a>text direction</a> is either empty, or one of `ltr` or `rtl`.</p>
 
     <p>Please note that concrete syntaxes MAY support
       <dfn data-lt="simple literal" class="export">simple literals</dfn> consisting of only a
@@ -708,8 +717,8 @@
 
     <ol>
       <li>If the literal is a <a>language-tagged string</a>,
-        then the literal value is a pair consisting of its <a>lexical form</a>
-        and its <a>language tag</a>, in that order.</li>
+        then the literal value is a tuple consisting of its <a>lexical form</a>,
+        its <a>language tag</a>, and its <a>text direction</a>, in that order.</li>
 
       <li>If the literal's <a>datatype IRI</a> is in the set of
         <a>recognized datatype IRIs</a>, let <var>d</var> be the
@@ -732,12 +741,15 @@
         not defined by this specification.</li>
     </ol>
 
-    <p><dfn data-local-lt="term-equal">Literal term equality</dfn>: Two literals are term-equal (the same
-      RDF literal) if and only if the two <a>lexical forms</a>,
-      the two <a>datatype IRIs</a>, and the two
-      <a>language tags</a> (if any) compare equal,
-      character by character. Thus, two literals can have the same value
-      without being the same RDF term. For example:</p>
+    <p><dfn data-local-lt="term-equal">Literal term equality</dfn>:
+      Two literals are term-equal (the same <a>RDF literal</a>)
+      if and only if the two <a>lexical forms</a>,
+      the two <a>datatype IRIs</a>,
+      the two <a>language tags</a> (if any), and
+      the two <a>text directions</a> (if any)
+      compare equal, character by character.
+      Thus, two literals can have the same value
+      without being the same <a>RDF term</a>. For example:</p>
 
     <pre>
       `"1"^^xs:integer`
@@ -748,6 +760,26 @@
       same literal <a>RDF terms</a> and are not
       <a>term-equal</a> because their
       <a>lexical form</a> differs.</p>
+
+    <section id="section-text-direction" class="informative">
+      <h3>Text Direction</h3>
+
+      <p>The <a>text direction</a> of a <a>language-tagged string</a>
+        provides means of establishing the direction of text
+        written or mixed with right-to-left scripts.
+        The [[[?UAX9]]] [[?UAX9]] provides support for automatically rendering
+        a sequence of characters in logical order,
+        so that they are visually ordered as expected.
+        However, this is not sufficient to correctly render bidirectional text.</p>
+
+      <p>For example, the <a>language-tagged string</a> `"פעילות הבינאום, W3C"`
+        expressed with language tag `he` will be displayed incorrectly
+        unless the <a>text direction</a> of `rtl` (for right-to-left)
+        is also provided.
+        When this is provided to a user agent,
+        for example using the HTML `dir` attribute,
+        this would be correctly presented as <br/><span lang="he" dir="rtl">פעילות הבינאום, W3C</span>.</p>
+    </section>
   </section>
 
   <section id="section-blank-nodes">
@@ -1636,6 +1668,9 @@
       for informative definition of a <a>quad</a>.</li>
     <li>Added <a href="#section-quoted-triples" class="sectionRef"></a>
       and definitions for <a>quoted triple</a> and <a>asserted triple</a>.</li>
+    <li>Added the <a>text direction</a> element as part of
+      a <a>language-tagged string</a>,
+      and a description of its use in <a href="#section-text-direction" class="sectionRef"></a>.</li>
   </ul>
 
   <p class="note">A detailed overview of the differences between RDF versions&nbsp;1.0

--- a/spec/index.html
+++ b/spec/index.html
@@ -700,8 +700,7 @@
     <p>A literal is a <dfn>language-tagged string</dfn> if the third element
       is present and the fourth element is not present.
       Lexical representations of language tags MAY be converted
-      to lower case or formatted according to  the recommendation for formatting language tags
-      as described in <a data-cite="BCP47#section-2.1.1">section 2.1.1</a> of [[BCP47]].
+      to lower case.
       The value of language tags is always treated as being in lower case.</p>
 
     <p>A literal is a <dfn id="dfn-dir-lang-string">directional language-tagged string</dfn>
@@ -758,7 +757,7 @@
       Two literals are term-equal (the same <a>RDF literal</a>)
       if and only if the two <a>lexical forms</a>,
       the two <a>datatype IRIs</a>,
-      the two <a>language tags</a> (if any) normalized to lower case, and
+      the two <a>language tags</a> (if any), and
       the two <a>base directions</a> (if any),
       all compare equal, character by character.
       Thus, two literals can have the same value

--- a/spec/index.html
+++ b/spec/index.html
@@ -68,9 +68,9 @@
 
   <p>RDF 1.2 introduces <a>quoted triples</a> as another kind of <a>RDF term</a>
     which can be used as the <a>subject</a> or <a>object</a> of another <a>triple</a>.
-    RDF 1.2 also introduces <a>directional language-tagged strings</a>
-    containing a <a>base direction</a> element allowing the
-    initial text direction to be specified when presented in a user agent.</p>
+    RDF 1.2 also introduces <a>directional language-tagged strings</a>,
+    which contain a <a>base direction</a> element that allows the
+    initial text direction to be specified for presentation by a user agent.</p>
 
   <p>RDF 1.2 Concepts introduces key concepts and terminology for RDF 1.2, discusses
     datatyping, and the handling of <a>fragment identifiers</a> in IRIs within
@@ -148,8 +148,8 @@
     resource denoted by a literal is called its
     <a>literal value</a>. Literals have
     <a>datatypes</a> that define the range of possible
-    values, such as strings, numbers, and dates. Special kind of literals,
-    <a>language-tagged strings</a> and <a>directional language-tagged strings</a>,
+    values, such as strings, numbers, and dates. Special kinds of literals &mdash;
+    <a>language-tagged strings</a> and <a>directional language-tagged strings</a> &mdash;
     respectively denote plain-text strings in a natural language, and plain-text
     strings in a natural language including an initial text direction.</p>
 
@@ -812,8 +812,8 @@
         including text which is a mixture of right-to-left and left-to-right scripts.
         The [[[?UAX9]]] [[?UAX9]] provides support for automatically rendering
         a sequence of characters in logical order,
-        so that they are visually ordered as expected.
-        However, this is not sufficient to correctly render bidirectional text.</p>
+        so that they are visually ordered as expected,
+        but this is not sufficient to correctly render bidirectional text.</p>
 
        <p>For example, some text with a language tag "`he`" might be displayed
          in a left-to-right context (such as an English web page) as

--- a/spec/index.html
+++ b/spec/index.html
@@ -765,16 +765,15 @@
       <h3>Text Direction</h3>
 
       <p>The <a>text direction</a> of a <a>language-tagged string</a>
-        provides means of establishing the direction of text
-        written or mixed with right-to-left scripts.
+        provides means of establishing the initial direction of text,
+        including text which is mixture of right-to-left and left-to-right scripts.
         The [[[?UAX9]]] [[?UAX9]] provides support for automatically rendering
         a sequence of characters in logical order,
         so that they are visually ordered as expected.
         However, this is not sufficient to correctly render bidirectional text.</p>
 
-      <p>For example, the <a>language-tagged string</a> `"פעילות הבינאום, W3C"`
-        expressed with language tag `he` will be displayed incorrectly
-        unless the <a>text direction</a> of `rtl` (for right-to-left)
+      <p>For example, the text `"פעילות הבינאום, W3C"` with language tag "he" may be displayed
+        incorrectly unless the <a>text direction</a> of `rtl` (for right-to-left)
         is also provided.
         When this is provided to a user agent,
         for example using the HTML `dir` attribute,
@@ -1668,8 +1667,8 @@
       for informative definition of a <a>quad</a>.</li>
     <li>Added <a href="#section-quoted-triples" class="sectionRef"></a>
       and definitions for <a>quoted triple</a> and <a>asserted triple</a>.</li>
-    <li>Added the <a>text direction</a> element as part of
-      a <a>language-tagged string</a>,
+    <li>Added the <a>text direction</a> element as part of 
+      a <a>literal</a>,
       and a description of its use in <a href="#section-text-direction" class="sectionRef"></a>.</li>
   </ul>
 


### PR DESCRIPTION
This addresses the conceptual representation of text direction in RDF language-tagged literals, based on discussion in:

* https://github.com/w3c/rdf-star-wg/blob/main/docs/text-direction.md, 
* [Internationalization Best Practices for Spec Developers](https://www.w3.org/TR/international-specs/#abstract),
* [Strings on the Web: Language and Direction Metadata](https://www.w3.org/TR/string-meta/), and
* [RDF Literals and Base Directions](https://w3c.github.io/rdf-dir-literal/).

Fixes #9.

For discussion:

* Separate `directional language-tagged string` with `rdf:dirLangString` datatype, or extend the notion of `language-tagged string` and continue to use `rdf:langString`.
* Bikeshedding terminology for literal element:
* [ ] `text direction` – From previous proposals
* [x] `base direction` – From [Unicode bidi basics](https://www.w3.org/International/articles/inline-bidi-markup/uba-basics)
* [ ] `initial text direction` – From [Wiki](https://github.com/w3c/rdf-star-wg/wiki/Text-Direction-considerations)
* [ ] `text directionality` – From HTML

(As the infrastructure seems to be having issues, you can also view the document via [GitHack](https://raw.githack.com/w3c/rdf-concepts/text-direction/spec/index.html).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/48.html" title="Last updated on Oct 13, 2023, 8:08 PM UTC (529b6dc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/48/2d855bb...529b6dc.html" title="Last updated on Oct 13, 2023, 8:08 PM UTC (529b6dc)">Diff</a>