### PR TITLE
firm up definition of IRI equality

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -593,11 +593,13 @@
       and MAY contain a fragment identifier.</p>
 
     <p><dfn>IRI equality</dfn>:
-      Two IRIs are equal if and only if they are <a>equivalent</a>
-      under Simple String Comparison according to
-      <a data-cite="rfc3987#section-5.1">section 5.1</a>
-      of [[!RFC3987]]. Further normalization MUST NOT be performed when
-      comparing IRIs for equality.</p>
+      Two IRIs are the same if and only if they compare as identical when
+      considered as character strings, as in Simple String Comparison in
+      section <a data-cite="rfc3987#section-5.3.1">section 5.3.1</a>
+      of [[!RFC3987]].
+      (This is done in the abstract syntax, so the IRIs are absolute
+      IRIs with no escaping or encoding.)
+      Further normalization MUST NOT be performed before this comparison. </p>
 
     <div class="note" id="note-iris">
       <p><strong>URIs and IRIs:</strong>

--- a/spec/index.html
+++ b/spec/index.html
@@ -595,7 +595,7 @@
     <p><dfn>IRI equality</dfn>:
       Two IRIs are the same if and only if they compare as identical when
       considered as character strings, as in Simple String Comparison in
-      section <a data-cite="rfc3987#section-5.3.1">section 5.3.1</a>
+      <a data-cite="rfc3987#section-5.3.1">section 5.3.1</a>
       of [[!RFC3987]].
       (This is done in the abstract syntax, so the IRIs are absolute
       IRIs with no escaping or encoding.)


### PR DESCRIPTION
I was looking at the definition of IRI equality and noticed a wrong link, a strange link, and a slight lack of rigour.  

This doesn't really change anything about IRI equality, just making the definition clearer.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/50.html" title="Last updated on Jun 23, 2023, 9:28 PM UTC (5bb8a5f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/50/b1b0d05...5bb8a5f.html" title="Last updated on Jun 23, 2023, 9:28 PM UTC (5bb8a5f)">Diff</a>