### PR TITLE
Remove markdown because inside markup

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -742,8 +742,8 @@
       without being the same RDF term. For example:</p>
 
     <pre>
-      `"1"^^xs:integer`
-      `"01"^^xs:integer`
+      "1"^^xs:integer
+      "01"^^xs:integer
     </pre>
 
     <p>denote the same <a data-lt="literal value">value</a>, but are not the


### PR DESCRIPTION
Use of backticks inside pre


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/54.html" title="Last updated on Jul 25, 2023, 9:18 PM UTC (e160659)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/54/332aed9...e160659.html" title="Last updated on Jul 25, 2023, 9:18 PM UTC (e160659)">Diff</a>