### PR TITLE
Adds a definition for "IRI reference".

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -601,7 +601,7 @@
         [[RFC3986]] that permits a wider range of Unicode characters.
         Every absolute URI and URL is an IRI, but not every IRI is an URI.
         In RDF, IRIs are used as <dfn data-lt="iri reference">IRI references</dfn>, as defined in [[RFC3987]]
-        <a data-cite="RFC3997#section-1.3">section 1.3</a>.
+        <a data-cite="RFC3987#section-1.3">section 1.3</a>.
         An IRI reference is common usage of an Internationalized Resource Identifier.
         An IRI reference may be absolute or relative.
         However, the <a>IRI</a> that results from such a reference

--- a/spec/index.html
+++ b/spec/index.html
@@ -462,7 +462,7 @@
       <a>RDF dataset</a>, for example through the use of
       <a>namespace prefixes</a>,
       <a>IRI references</a>, <a>blank node identifiers</a>,
-      and different ordering of statements. While these aspects can have great
+      and different ordering of triples. While these aspects can have great
       effect on the convenience of working with the <a>RDF document</a>,
       they are not significant for its meaning.</p>
   </section>

--- a/spec/index.html
+++ b/spec/index.html
@@ -603,10 +603,9 @@
         In RDF, IRIs are used as <dfn data-lt="iri reference">IRI references</dfn>, as defined in [[RFC3987]]
         <a data-cite="RFC3987#section-1.3">section 1.3</a>.
         An IRI reference is common usage of an Internationalized Resource Identifier.
-        An IRI reference may be absolute or relative.
-        However, the <a>IRI</a> that results from such a reference
-        only includes absolute IRIs; any <a>relative IRI references</a> are
-        resolved to their absolute form.
+        An IRI reference refers to either <a>IRI</a> or <a>relative IRI reference</a>,
+        as described by the <em>IRI-reference</em> production in <a href="#iri-abnf" class="sectionRef"></a>.
+        The abstract syntax uses only fully resolved <a>IRIs</a>.
         When IRIs are used in operations that are only
         defined for URIs, they must first be converted according to
         the mapping defined in

--- a/spec/index.html
+++ b/spec/index.html
@@ -461,7 +461,7 @@
       many different ways to encode the same <a>RDF graph</a> or
       <a>RDF dataset</a>, for example through the use of
       <a>namespace prefixes</a>,
-      <a>relative IRI references</a>, <a>blank node identifiers</a>,
+      <a>IRI references</a>, <a>blank node identifiers</a>,
       and different ordering of statements. While these aspects can have great
       effect on the convenience of working with the <a>RDF document</a>,
       they are not significant for its meaning.</p>
@@ -600,7 +600,13 @@
         <dfn data-lt="URI" data-lt-noDefault><abbr title="Uniform Resource Identifier">URI</abbr>s</dfn>
         [[RFC3986]] that permits a wider range of Unicode characters.
         Every absolute URI and URL is an IRI, but not every IRI is an URI.
-        In RDF, IRIs are used as <em>IRI references</em>, as defined in [[RFC3987]].
+        In RDF, IRIs are used as <dfn data-lt="iri reference">IRI references</dfn>, as defined in [[RFC3987]]
+        <a data-cite="RFC3997#section-1.3">section 1.3</a>.
+        An IRI reference is common usage of an Internationalized Resource Identifier.
+        An IRI reference may be absolute or relative.
+        However, the <a>IRI</a> that results from such a reference
+        only includes absolute IRIs; any <a>relative IRI references</a> are
+        resolved to their absolute form.
         When IRIs are used in operations that are only
         defined for URIs, they must first be converted according to
         the mapping defined in


### PR DESCRIPTION
We had defined "IRI" and "relative IRI reference", but not "IRI reference. This allows other specs to refer to RDF Concepts for all such terms.

For #20.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/57.html" title="Last updated on Aug 17, 2023, 8:09 PM UTC (5e3cbe4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/57/bf2d6ea...5e3cbe4.html" title="Last updated on Aug 17, 2023, 8:09 PM UTC (5e3cbe4)">Diff</a>