### PR TITLE
Improve Unicode terminology and term references.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -496,6 +496,25 @@
     and still the subject of group discussion. An alternative to conformance
     levels, "profiles", may be adopted instead, abandoned, or described in 
     another specification.</p>
+
+  <section id="rdf-strings">
+    <h2>Strings in RDF</h2>
+
+    <p>RDF uses Unicode [[Unicode]] as the fundamental representation for string values.
+      Within this, and related specifications, the term <dfn id="dfn-rdf-string">string</dfn>
+      is used to describe an ordered sequence of zero or more <a data-lt="code point" class="lint-ignore">Unicode code points</a>
+      in any <a data-cite="i18n-glossary#dfn-character-set">character set</a>
+      or <a data-cite="i18n-glossary#dfn-character-encoding">character encoding</a>.
+      However, note that most <a>concrete RDF syntaxes</a>
+      are restricted to the UTF-8 character encoding [[!RFC3629]].
+      Strings are further restricted to those matching the
+      <a data-cite="XML10#charsets">Char</a> production [[XML10]].</p>
+
+    <p>A string is identical to another string if it consists of the same sequence of code points.
+      An implementation MAY determine string equality by comparing the <a data-cite="i18n-glossary#dfn-code-unit">code units</a> of two strings
+      using the same <a data-cite="i18n-glossary#dfn-character-encoding">Unicode character encoding</a> form
+      (UTF-8 or UTF-16) without decoding the string into a <a data-cite="i18n-glossary#dfn-scalar-value">scalar value</a> sequence.</p>
+  </section>
 </section>
 
 
@@ -577,7 +596,7 @@
 
     <p>An <dfn data-lt="iri"><abbr title="Internationalized Resource Identifier">IRI</abbr></dfn>
       (Internationalized Resource Identifier) within an RDF graph
-      is a Unicode string [[!UNICODE]] that conforms to the syntax
+      is a <a>string</a> that conforms to the syntax
       defined in RFC 3987 [[!RFC3987]].</p>
 
     <p class="note">For convenience, a complete [[ABNF]] grammar
@@ -738,7 +757,8 @@
       RDF literal) if and only if the two <a>lexical forms</a>,
       the two <a>datatype IRIs</a>, and the two
       <a>language tags</a> (if any) compare equal,
-      using <a data-cite="i18n-glossary#dfn-case-sensitive">case sensitive matching</a>.
+      using <a data-cite="i18n-glossary#dfn-case-sensitive">case sensitive matching</a>
+      (see description of string comparison in <a href="#rdf-strings" class="sectionRef"></a>).
       Thus, two literals can have the same value
       without being the same RDF term. For example:</p>
 
@@ -981,7 +1001,7 @@
     a <a>value space</a> and a <a>lexical-to-value mapping</a>, and
     is denoted by one or more <a>IRIs</a>.</p>
 
-  <p>The <dfn>lexical space</dfn> of a datatype is a set of Unicode strings [[!UNICODE]].</p>
+  <p>The <dfn>lexical space</dfn> of a datatype is a set of <a>strings</a>.</p>
 
   <p>The <dfn>lexical-to-value mapping</dfn> of a datatype is a set of
     pairs whose first element belongs to the <a>lexical space</a>,
@@ -1064,7 +1084,7 @@
       <caption>A list of the RDF-compatible XSD types, with short descriptions</caption>
       <tr><th></th><th>Datatype</th><th>Value space (informative)</th></tr>
 
-      <tr><th rowspan="4">Core types</th><td><a data-cite="xmlschema11-2#string"><code>xsd:string</code></a></td><td>Character strings (but not all Unicode strings [[UNICODE]])</td></tr>
+      <tr><th rowspan="4">Core types</th><td><a data-cite="xmlschema11-2#string"><code>xsd:string</code></a></td><td>Character strings (but not all Unicode <a>strings</a> [[UNICODE]])</td></tr>
       <tr><td><a data-cite="xmlschema11-2#boolean"><code>xsd:boolean</code></a></td><td>true, false</td></tr>
       <tr><td><a data-cite="xmlschema11-2#decimal"><code>xsd:decimal</code></a></td><td>Arbitrary-precision decimal numbers</td></tr>
       <tr><td><a data-cite="xmlschema11-2#integer"><code>xsd:integer</code></a></td><td>Arbitrary-size integer numbers</td></tr>
@@ -1222,9 +1242,6 @@
       <dt>The IRI denoting this datatype</dt>
       <dd>is <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML</code>.</dd>
 
-      <dt>The lexical space</dt>
-      <dd>is the set of Unicode strings [[!UNICODE]].</dd>
-
       <dt>The value space</dt>
       <dd>is a set of DOM
         <a data-cite="DOM#interface-documentfragment"><code>DocumentFragment</code></a>
@@ -1278,11 +1295,11 @@
       <dd>is <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral</code>.</dd>
 
       <dt id="XMLLiteral-lexical-space">The <a>lexical space</a></dt>
-      <dd>is the set of all Unicode strings [[UNICODE]] which are well-balanced, self-contained
-        <a data-cite="XML10#NT-content">XML content</a>
-        [[XML10]]; and for which embedding between an arbitrary
-        XML start tag and an end tag yields a document conforming to
-       [[[XML-NAMES]]] [[XML-NAMES]].</dd>
+      <dd>is the set of all <a>strings</a> which are well-balanced,
+        self-contained <a data-cite="XML10#NT-content">XML content</a> [[XML10]];
+        and for which embedding between an arbitrary
+        XML start tag and an end tag yields
+        a document conforming to [[[XML-NAMES]]] [[XML-NAMES]].</dd>
 
       <dt id="XMLLiteral-value-space">The <a>value space</a></dt>
         <dd>is a set of DOM
@@ -1462,7 +1479,7 @@
     Security/privacy protocols must be imposed which reflect the sensitivity of the embedded information.</p>
 
   <p>RDF can express data which is presented to the user, such as RDF Schema labels.
-    Applications rendering strings retrieved from untrusted RDF documents,
+    Applications rendering <a>strings</a> retrieved from untrusted RDF documents,
     or using unescaped characters,
     SHOULD use warnings and other appropriate means to limit the possibility
     that malignant strings might be used to mislead the reader.
@@ -1494,7 +1511,7 @@
 
 <section id="internationalization" class="appendix informative">
   <h2>Internationalization Considerations</h2>
-  <p>RDF is restricted to representing Unicode string [[UNICODE]] values with left-to-right or right-to-left direction indicators.
+  <p>RDF is restricted to representing Unicode <a>string</a> [[UNICODE]] values with left-to-right or right-to-left direction indicators.
     RDF provides a mechanism for specifying the language associated with
     a string (<a>language-tagged string</a>),
     but does not provide a means of indicating the base direction of the string.</p>
@@ -1655,9 +1672,10 @@
     <li>Changed reference from DOM4, which was not a recommendation at the time, to [[DOM]],
       making the <a>rdf:HTML</a> and <a>rdf:XMLLiteral</a> datatypes normative.</li>
     <li>Clarify Unicode terminology,
-      using a data-lt="code point" class="lint-ignore">Unicode code points</a>,
+      using <a data-lt="code point" class="lint-ignore">Unicode code points</a>,
       and restriction to the XML <a data-cite="XML10#charsets">Char</a> production.
-      Also removes obsolete recommendations for the use of Normalization Form C in literals.</li>
+      Also removes obsolete recommendations for the use of Normalization Form C in literals.
+      Adds a definition of <a>string</a> that can be used in other RDF documents.</li>
   </ul>
 
   <p class="note">A detailed overview of the differences between RDF versions&nbsp;1.0

--- a/spec/index.html
+++ b/spec/index.html
@@ -509,7 +509,7 @@ of the UTF-8 character encoding [[!RFC3629]],
 which also prevents the use of certain non-character values.
       are restricted to the UTF-8 character encoding [[!RFC3629]].
       Strings are further restricted to those matching the
-      <a data-cite="XML10#charsets">Char</a> production [[XML10]].</p>
+      <a data-cite="XML11#charsets">Char</a> production [[XML11]].</p>
 
     <p>A string is identical to another string if it consists of the same sequence of code points.
       An implementation MAY determine string equality by comparing the <a data-cite="i18n-glossary#dfn-code-unit">code units</a> of two strings
@@ -1298,7 +1298,7 @@ which also prevents the use of certain non-character values.
 
       <dt id="XMLLiteral-lexical-space">The <a>lexical space</a></dt>
       <dd>is the set of all <a>strings</a> which are well-balanced,
-        self-contained <a data-cite="XML10#NT-content">XML content</a> [[XML10]];
+        self-contained <a data-cite="XML11#NT-content">XML content</a> [[XML11]];
         and for which embedding between an arbitrary
         XML start tag and an end tag yields
         a document conforming to [[[XML-NAMES]]] [[XML-NAMES]].</dd>
@@ -1675,7 +1675,7 @@ which also prevents the use of certain non-character values.
       making the <a>rdf:HTML</a> and <a>rdf:XMLLiteral</a> datatypes normative.</li>
     <li>Clarify Unicode terminology,
       using <a data-lt="code point" class="lint-ignore">Unicode code points</a>,
-      and restriction to the XML <a data-cite="XML10#charsets">Char</a> production.
+      and restriction to the XML <a data-cite="XML11#charsets">Char</a> production.
       Also removes obsolete recommendations for the use of Normalization Form C in literals.
       Adds a definition of <a>string</a> that can be used in other RDF documents.</li>
   </ul>

--- a/spec/index.html
+++ b/spec/index.html
@@ -695,7 +695,7 @@
     <ul>
       <li>a <dfn>lexical form</dfn> consisting of a sequence of
         <a data-lt="code point" class="lint-ignore">Unicode code points</a> [[!UNICODE]]
-        which are <a data-cite="i18n-glossary#dfn-scalar-value">Unicode scalar values</a>, thus, they do not contain Unicode surrogate code points.</li>
+        which are <a data-cite="i18n-glossary#dfn-scalar-value">Unicode scalar values</a>, and therefore do not contain Unicode surrogate code points.</li>
       <li>a <dfn>datatype IRI</dfn>, being an <a>IRI</a>
         identifying a datatype that determines how the lexical form maps
         to a <a>literal value</a>, and</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1650,7 +1650,8 @@
       making the <a>rdf:HTML</a> and <a>rdf:XMLLiteral</a> datatypes normative.</li>
     <li>Clarify Unicode terminology,
       using a data-lt="code point" class="lint-ignore">Unicode code points</a>,
-      and restriction to the XML <a data-cite="XML10#charsets">Char</a> production.</li>
+      and restriction to the XML <a data-cite="XML10#charsets">Char</a> production.
+      Also removes obsolete recommendations for the use of Normalization Form C in literals.</li>
   </ul>
 
   <p class="note">A detailed overview of the differences between RDF versions&nbsp;1.0

--- a/spec/index.html
+++ b/spec/index.html
@@ -587,7 +587,7 @@
 
     <p><dfn>IRI equality</dfn>:
       Two IRIs are the same if and only if they compare as identical when
-      considered as character strings, as in Simple String Comparison in
+      considered as character strings (unicode strings), as in Simple String Comparison in
       <a data-cite="rfc3987#section-5.3.1">section 5.3.1</a>
       of [[!RFC3987]].
       (This is done in the abstract syntax, so the IRIs are absolute
@@ -738,7 +738,8 @@
       RDF literal) if and only if the two <a>lexical forms</a>,
       the two <a>datatype IRIs</a>, and the two
       <a>language tags</a> (if any) compare equal,
-      character by character. Thus, two literals can have the same value
+      using <a data-cite="i18n-glossary#dfn-case-sensitive">character sensitive matching</a>.
+      Thus, two literals can have the same value
       without being the same RDF term. For example:</p>
 
     <pre>

--- a/spec/index.html
+++ b/spec/index.html
@@ -503,8 +503,7 @@
     <p>RDF uses Unicode [[Unicode]] as the fundamental representation for string values.
       Within this, and related specifications, the term <dfn id="dfn-rdf-string">string</dfn>
       is used to describe an ordered sequence of zero or more <a data-lt="code point" class="lint-ignore">Unicode code points</a>
-      in any <a data-cite="i18n-glossary#dfn-character-set">character set</a>
-      or <a data-cite="i18n-glossary#dfn-character-encoding">character encoding</a>.
+      in any <a data-cite="i18n-glossary#dfn-character-encoding">character encoding</a>.
       However, note that most <a>concrete RDF syntaxes</a>
       are restricted to the UTF-8 character encoding [[!RFC3629]].
       Strings are further restricted to those matching the

--- a/spec/index.html
+++ b/spec/index.html
@@ -197,7 +197,8 @@
       </figcaption>
     </figure>
 
-    <p>A variation on the graph shown in <a href="#fig-quoted-triple"></a> can be described where the <a>quoted triple</a> is also <a data-lt="asserted triple">asserted</a>.</p>
+    <p>A variation on the graph shown in <a href="#fig-quoted-triple"></a> can be described
+      where the <a>quoted triple</a> is also <a data-lt="asserted triple">asserted</a>.</p>
 
     <figure id="fig-quoted-asserted-triple">
       <a href="quoted-asserted-triple.svg">
@@ -208,7 +209,8 @@
              aria-describedby="fig-quoted-asserted-triple-alt"/>
       </a>
       <figcaption id="fig-quoted-asserted-triple-alt">
-        An RDF graph containing two triples where one of them contains the other as the subject; hence, that other triple is both quoted and asserted.
+        An RDF graph containing two triples where one of them contains the other as the subject;
+        hence, that other triple is both quoted and asserted.
       </figcaption>
     </figure>
 
@@ -503,7 +505,11 @@
     <p>RDF uses Unicode [[Unicode]] as the fundamental representation for string values.
       Within this, and related specifications, the term <dfn id="dfn-rdf-string">string</dfn>,
       or <a data-lt="string">RDF string</a>,
-      `is used to describe an ordered` sequence of zero or more <a data-lt="code point" class="lint-ignore">Unicode code points</a> which are <a data-cite="i18n-glossary#dfn-scalar-value" class="lint-ignore">Unicode scalar values</a>. Unicode scalar values do not include the <a data-cite="i18n-glossary#dfn-surrogate"  class="lint-ignore">surrogate code points</a>.
+      `is used to describe an ordered` sequence of zero or more
+      <a data-lt="code point" class="lint-ignore">Unicode code points</a>
+      which are <a data-cite="i18n-glossary#dfn-scalar-value" class="lint-ignore">Unicode scalar values</a>.
+      Unicode scalar values do not include the
+      <a data-cite="i18n-glossary#dfn-surrogate" class="lint-ignore">surrogate code points</a>.
       Note that most <a>concrete RDF syntaxes</a> require the use
       of the UTF-8 character encoding [[!RFC3629]], 
       which requires that certain non-character values be expressed
@@ -511,9 +517,11 @@
 </p>
 
     <p>A string is identical to another string if it consists of the same sequence of code points.
-      An implementation MAY determine string equality by comparing the <a data-cite="i18n-glossary#dfn-code-unit">code units</a> of two strings
+      An implementation MAY determine string equality by comparing the
+      <a data-cite="i18n-glossary#dfn-code-unit">code units</a> of two strings
       that use the same <a data-cite="i18n-glossary#dfn-character-encoding">Unicode character encoding</a>
-      (UTF-8 or UTF-16) without decoding the string into a <a data-lt="code point" class="lint-ignore">Unicode code point</a> sequence.</p>
+      (UTF-8 or UTF-16) without decoding the string into a
+      <a data-lt="code point" class="lint-ignore">Unicode code point</a> sequence.</p>
   </section>
 </section>
 
@@ -695,7 +703,9 @@
     <ul>
       <li>a <dfn>lexical form</dfn> consisting of a sequence of
         <a data-lt="code point" class="lint-ignore">Unicode code points</a> [[!UNICODE]]
-        which are <a data-cite="i18n-glossary#dfn-scalar-value">Unicode scalar values</a>, and therefore do not contain <a data-cite="i18n-glossary#dfn-surrogate"  class="lint-ignore">Unicode surrogate code points</a>.</li>
+        which are <a data-cite="i18n-glossary#dfn-scalar-value">Unicode scalar values</a>,
+        and therefore do not contain
+        <a data-cite="i18n-glossary#dfn-surrogate" class="lint-ignore">Unicode surrogate code points</a>.</li>
       <li>a <dfn>datatype IRI</dfn>, being an <a>IRI</a>
         identifying a datatype that determines how the lexical form maps
         to a <a>literal value</a>, and</li>
@@ -852,8 +862,9 @@
 
     <p id="section-graph-equality">Two
       <a>RDF graphs</a> <var>G</var> and <var>G'</var> are
-      <dfn data-lt="graph isomorphism|isomorphic" data-lt-noDefault class="export">isomorphic</dfn> (that is, they have an identical
-      form) if there is a bijection <var>M</var> between the sets of nodes of the two
+      <dfn data-lt="graph isomorphism|isomorphic" data-lt-noDefault class="export">isomorphic</dfn>
+      (that is, they have an identical form)
+      if there is a bijection <var>M</var> between the sets of nodes of the two
       graphs, such that:</p>
 
     <ol>

--- a/spec/index.html
+++ b/spec/index.html
@@ -506,15 +506,15 @@
       in any <a data-cite="i18n-glossary#dfn-character-encoding">character encoding</a>.
       Note that most <a>concrete RDF syntaxes</a> require the use
       of the UTF-8 character encoding [[!RFC3629]], 
-      which also prevents the use of certain non-character values.
+      which requires that certain non-character values be expressed
+      using the `\u0000` or `\U00000000` forms.
       are restricted to the UTF-8 character encoding [[!RFC3629]].
-      Strings are further restricted to those matching the
-      <a data-cite="XML11#charsets">Char</a> production [[XML11]].</p>
+</p>
 
     <p>A string is identical to another string if it consists of the same sequence of code points.
       An implementation MAY determine string equality by comparing the <a data-cite="i18n-glossary#dfn-code-unit">code units</a> of two strings
       using the same <a data-cite="i18n-glossary#dfn-character-encoding">Unicode character encoding</a> form
-      (UTF-8 or UTF-16) without decoding the string into a <a data-cite="i18n-glossary#dfn-scalar-value">scalar value</a> sequence.</p>
+      (UTF-8 or UTF-16) without decoding the string into a <a data-lt="code point" class="lint-ignore">Unicode code point</a> sequence.</p>
   </section>
 </section>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -503,8 +503,7 @@
     <p>RDF uses Unicode [[Unicode]] as the fundamental representation for string values.
       Within this, and related specifications, the term <dfn id="dfn-rdf-string">string</dfn>,
       or <a data-lt="string">RDF string</a>,
-      is used to describe an ordered sequence of zero or more <a data-lt="code point" class="lint-ignore">Unicode code points</a> which are <a data-cite="i18n-glossary#dfn-scalar-value" class="lint-ignore">Unicode scalar values</a>, which do not include Unicode surrogate code points.
-      in any <a data-cite="i18n-glossary#dfn-character-encoding">character encoding</a>.
+      `is used to describe an ordered` sequence of zero or more <a data-lt="code point" class="lint-ignore">Unicode code points</a> which are <a data-cite="i18n-glossary#dfn-scalar-value" class="lint-ignore">Unicode scalar values</a>. Unicode scalar values do not include the <a data-cite="i18n-glossary#dfn-surrogate"  class="lint-ignore">surrogate code points</a>.
       Note that most <a>concrete RDF syntaxes</a> require the use
       of the UTF-8 character encoding [[!RFC3629]], 
       which requires that certain non-character values be expressed
@@ -696,7 +695,7 @@
     <ul>
       <li>a <dfn>lexical form</dfn> consisting of a sequence of
         <a data-lt="code point" class="lint-ignore">Unicode code points</a> [[!UNICODE]]
-        which are <a data-cite="i18n-glossary#dfn-scalar-value">Unicode scalar values</a>, and therefore do not contain Unicode surrogate code points.</li>
+        which are <a data-cite="i18n-glossary#dfn-scalar-value">Unicode scalar values</a>, and therefore do not contain <a data-cite="i18n-glossary#dfn-surrogate"  class="lint-ignore">Unicode surrogate code points</a>.</li>
       <li>a <dfn>datatype IRI</dfn>, being an <a>IRI</a>
         identifying a datatype that determines how the lexical form maps
         to a <a>literal value</a>, and</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -504,7 +504,9 @@
       Within this, and related specifications, the term <dfn id="dfn-rdf-string">string</dfn>
       is used to describe an ordered sequence of zero or more <a data-lt="code point" class="lint-ignore">Unicode code points</a>
       in any <a data-cite="i18n-glossary#dfn-character-encoding">character encoding</a>.
-      However, note that most <a>concrete RDF syntaxes</a>
+Note that most <a>concrete RDF syntaxes</a> require the use
+of the UTF-8 character encoding [[!RFC3629]], 
+which also prevents the use of certain non-character values.
       are restricted to the UTF-8 character encoding [[!RFC3629]].
       Strings are further restricted to those matching the
       <a data-cite="XML10#charsets">Char</a> production [[XML10]].</p>
@@ -1083,7 +1085,7 @@
       <caption>A list of the RDF-compatible XSD types, with short descriptions</caption>
       <tr><th></th><th>Datatype</th><th>Value space (informative)</th></tr>
 
-      <tr><th rowspan="4">Core types</th><td><a data-cite="xmlschema11-2#string"><code>xsd:string</code></a></td><td>Character strings (but not all Unicode <a>strings</a> [[UNICODE]])</td></tr>
+      <tr><th rowspan="4">Core types</th><td><a data-cite="xmlschema11-2#string"><code>xsd:string</code></a></td><td>Character strings (see <a>string</a>)</td></tr>
       <tr><td><a data-cite="xmlschema11-2#boolean"><code>xsd:boolean</code></a></td><td>true, false</td></tr>
       <tr><td><a data-cite="xmlschema11-2#decimal"><code>xsd:decimal</code></a></td><td>Arbitrary-precision decimal numbers</td></tr>
       <tr><td><a data-cite="xmlschema11-2#integer"><code>xsd:integer</code></a></td><td>Arbitrary-size integer numbers</td></tr>

--- a/spec/index.html
+++ b/spec/index.html
@@ -687,7 +687,7 @@
           “<code>%3f</code>”)</li>
         <li>Punycode-encoding of Internationalized Domain Names
           in IRIs</li>
-        <li>IRIs that are not in Unicode <a class="lint-ignore">Normalization Form C</a> [[UNICODE]]</li>
+        <li>IRIs that are not in Unicode <a class="lint-ignore">Normalization Form C</a> [[UAX15]]</li>
       </ul>
     </div>
   </section>

--- a/spec/index.html
+++ b/spec/index.html
@@ -696,7 +696,8 @@ which also prevents the use of certain non-character values.
     <ul>
       <li>a <dfn>lexical form</dfn> consisting of a sequence of
         <a data-lt="code point" class="lint-ignore">Unicode code points</a> [[!UNICODE]]
-        matching the <a data-cite="XML10#charsets">Char</a> production [[XML10]].</li>
+        matching the <a data-cite="XML11#charsets">Char</a> production [[XML11]].</li>
+       Because RDF lexical forms match the Char production of XML they do not contain Unicode surrogate code points.
       <li>a <dfn>datatype IRI</dfn>, being an <a>IRI</a>
         identifying a datatype that determines how the lexical form maps
         to a <a>literal value</a>, and</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -33,6 +33,7 @@
         { name: "Brian McBride" }
       ],
 
+      xref: ["i18n-glossary"],
       github: "https://github.com/w3c/rdf-concepts/",
       group:           "rdf-star",
       doJsonLd:     true,
@@ -586,10 +587,10 @@
       and MAY contain a fragment identifier.</p>
 
     <p><dfn>IRI equality</dfn>:
-      Two IRIs are the same if and only if they compare as identical when
-      considered as character strings (Unicode strings), as in Simple String Comparison in
-      <a data-cite="rfc3987#section-5.3.1">section 5.3.1</a>
-      of [[!RFC3987]].
+      Two IRIs are the same if and only if they consist of the same sequence of
+      <a data-lt="code point" class="lint-ignore">Unicode code points</a>,
+      as in Simple String Comparison in
+      <a data-cite="rfc3987#section-5.3.1">section 5.3.1</a> of [[!RFC3987]].
       (This is done in the abstract syntax, so the IRIs are absolute
       IRIs with no escaping or encoding.)
       Further normalization MUST NOT be performed before this comparison. </p>
@@ -598,7 +599,7 @@
       <p><strong>URIs and IRIs:</strong>
         IRIs are a generalization of
         <dfn data-lt="URI" data-lt-noDefault><abbr title="Uniform Resource Identifier">URI</abbr>s</dfn>
-        [[RFC3986]] that permits a wider range from the Unicode <a data-cite="i18n-glossary#dfn-unicode">universal character set</a> [[UNICODE]].
+        [[RFC3986]] that permits a wider range of Unicode characters [[UNICODE]].
         Every absolute URI and URL is an IRI, but not every IRI is an URI.
         In RDF, IRIs are used as <dfn data-lt="iri reference">IRI references</dfn>, as defined in [[RFC3987]]
         <a data-cite="RFC3987#section-1.3">section 1.3</a>.
@@ -658,7 +659,7 @@
           “<code>%3f</code>”)</li>
         <li>Punycode-encoding of Internationalized Domain Names
           in IRIs</li>
-        <li>IRIs that are not in Unicode <a data-cite="i18n-glossary#dfn-unicode-normalization-form-c">Normalization Form&nbsp;C</a> [[UNICODE]]</li>
+        <li>IRIs that are not in Unicode <a class="lint-ignore">Normalization Form C</a> [[UNICODE]]</li>
       </ul>
     </div>
   </section>
@@ -672,11 +673,9 @@
       elements:</p>
 
     <ul>
-      <li>a <dfn>lexical form</dfn>, being a Unicode string [[!UNICODE]],
-        which SHOULD be in <a data-cite="i18n-glossary#dfn-unicode-normalization-form-c">Normalization Form&nbsp;C</a> [[!UNICODE]]
-        and where all <a data-cite="i18n-glossary#dfn-code-point">code points</a> MUST be
-        <a data-cite="i18n-glossary#dfn-scalar-value">Unicode scalar values</a>
-        (i.e., not include <a data-cite="i18n-glossary#dfn-surrogate">surrogate code points</a>).</li>
+      <li>a <dfn>lexical form</dfn> consisting of a sequence of
+        <a data-lt="code point" class="lint-ignore">Unicode code points</a> [[!UNICODE]]
+        matching the <a data-cite="XML10#charsets">Char</a> production [[XML10]].</li>
       <li>a <dfn>datatype IRI</dfn>, being an <a>IRI</a>
         identifying a datatype that determines how the lexical form maps
         to a <a>literal value</a>, and</li>
@@ -738,7 +737,7 @@
       RDF literal) if and only if the two <a>lexical forms</a>,
       the two <a>datatype IRIs</a>, and the two
       <a>language tags</a> (if any) compare equal,
-      using <a data-cite="i18n-glossary#dfn-case-sensitive">character sensitive matching</a>.
+      using <a data-cite="i18n-glossary#dfn-case-sensitive">case sensitive matching</a>.
       Thus, two literals can have the same value
       without being the same RDF term. For example:</p>
 
@@ -1649,7 +1648,9 @@
       and definitions for <a>quoted triple</a> and <a>asserted triple</a>.</li>
     <li>Changed reference from DOM4, which was not a recommendation at the time, to [[DOM]],
       making the <a>rdf:HTML</a> and <a>rdf:XMLLiteral</a> datatypes normative.</li>
-    <li>Clarify Unicode terminology. Excludes <a data-cite="i18n-glossary#dfn-surrogate">surrogate code points</a> from literals.</li>
+    <li>Clarify Unicode terminology,
+      using a data-lt="code point" class="lint-ignore">Unicode code points</a>,
+      and restriction to the XML <a data-cite="XML10#charsets">Char</a> production.</li>
   </ul>
 
   <p class="note">A detailed overview of the differences between RDF versions&nbsp;1.0

--- a/spec/index.html
+++ b/spec/index.html
@@ -504,9 +504,9 @@
       Within this, and related specifications, the term <dfn id="dfn-rdf-string">string</dfn>
       is used to describe an ordered sequence of zero or more <a data-lt="code point" class="lint-ignore">Unicode code points</a>
       in any <a data-cite="i18n-glossary#dfn-character-encoding">character encoding</a>.
-Note that most <a>concrete RDF syntaxes</a> require the use
-of the UTF-8 character encoding [[!RFC3629]], 
-which also prevents the use of certain non-character values.
+      Note that most <a>concrete RDF syntaxes</a> require the use
+      of the UTF-8 character encoding [[!RFC3629]], 
+      which also prevents the use of certain non-character values.
       are restricted to the UTF-8 character encoding [[!RFC3629]].
       Strings are further restricted to those matching the
       <a data-cite="XML11#charsets">Char</a> production [[XML11]].</p>
@@ -696,8 +696,8 @@ which also prevents the use of certain non-character values.
     <ul>
       <li>a <dfn>lexical form</dfn> consisting of a sequence of
         <a data-lt="code point" class="lint-ignore">Unicode code points</a> [[!UNICODE]]
-        matching the <a data-cite="XML11#charsets">Char</a> production [[XML11]].</li>
-       Because RDF lexical forms match the Char production of XML they do not contain Unicode surrogate code points.
+        matching the <a data-cite="XML11#charsets">Char</a> production [[XML11]].
+       Because RDF lexical forms match the Char production of XML they do not contain Unicode surrogate code points.</li>
       <li>a <dfn>datatype IRI</dfn>, being an <a>IRI</a>
         identifying a datatype that determines how the lexical form maps
         to a <a>literal value</a>, and</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -512,8 +512,7 @@
       <a data-cite="i18n-glossary#dfn-surrogate" class="lint-ignore">surrogate code points</a>.
       Note that most <a>concrete RDF syntaxes</a> require the use
       of the UTF-8 character encoding [[!RFC3629]], 
-      which requires that certain non-character values be expressed
-      using the `\u0000` or `\U00000000` forms.
+      and use the `\u0000` or `\U00000000` forms to express certain non-character values.
 </p>
 
     <p>A string is identical to another string if it consists of the same sequence of code points.
@@ -686,7 +685,7 @@
           triplets (“<code>%3F</code>” is preferable over
           “<code>%3f</code>”)</li>
         <li>Punycode-encoding of Internationalized Domain Names
-          in IRIs</li>
+          in IRIs [[RFC3492]]</li>
         <li>IRIs that are not in Unicode <a class="lint-ignore">Normalization Form C</a> [[UAX15]]</li>
       </ul>
     </div>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1648,7 +1648,7 @@
       and definitions for <a>quoted triple</a> and <a>asserted triple</a>.</li>
     <li>Changed reference from DOM4, which was not a recommendation at the time, to [[DOM]],
       making the <a>rdf:HTML</a> and <a>rdf:XMLLiteral</a> datatypes normative.</li>
-    <li>Clarify Unicode terminology.</li>
+    <li>Clarify Unicode terminology. Excludes <a data-cite="i18n-glossary#dfn-surrogate">surrogate code points</a> from literals.</li>
   </ul>
 
   <p class="note">A detailed overview of the differences between RDF versions&nbsp;1.0

--- a/spec/index.html
+++ b/spec/index.html
@@ -576,7 +576,7 @@
 
     <p>An <dfn data-lt="iri"><abbr title="Internationalized Resource Identifier">IRI</abbr></dfn>
       (Internationalized Resource Identifier) within an RDF graph
-      is a Unicode string [[!UNICODE]] that conforms to the syntax
+      is a unicode string [[!UNICODE]] that conforms to the syntax
       defined in RFC 3987 [[!RFC3987]].</p>
 
     <p class="note">For convenience, a complete [[ABNF]] grammar
@@ -598,7 +598,7 @@
       <p><strong>URIs and IRIs:</strong>
         IRIs are a generalization of
         <dfn data-lt="URI" data-lt-noDefault><abbr title="Uniform Resource Identifier">URI</abbr>s</dfn>
-        [[RFC3986]] that permits a wider range of Unicode characters.
+        [[RFC3986]] that permits a wider range from the Unicode <a data-cite="i18n-glossary#dfn-unicode">universal character set</a> [[UNICODE]].
         Every absolute URI and URL is an IRI, but not every IRI is an URI.
         In RDF, IRIs are used as <dfn data-lt="iri reference">IRI references</dfn>, as defined in [[RFC3987]]
         <a data-cite="RFC3987#section-1.3">section 1.3</a>.
@@ -658,8 +658,7 @@
           “<code>%3f</code>”)</li>
         <li>Punycode-encoding of Internationalized Domain Names
           in IRIs</li>
-        <li>IRIs that are not in Unicode Normalization
-          Form C [[NFC]]</li>
+        <li>IRIs that are not in Unicode <a data-cite="i18n-glossary#dfn-unicode-normalization-form-c">Normalization Form&nbsp;C</a> [[UNICODE]]</li>
       </ul>
     </div>
   </section>
@@ -673,8 +672,11 @@
       elements:</p>
 
     <ul>
-      <li>a <dfn>lexical form</dfn>, being a Unicode [[!UNICODE]] string,
-        which SHOULD be in Normal Form&nbsp;C [[!NFC]],</li>
+      <li>a <dfn>lexical form</dfn>, being a unicode string [[!UNICODE]],
+        which SHOULD be in <a data-cite="i18n-glossary#dfn-unicode-normalization-form-c">Normalization Form&nbsp;C</a> [[!UNICODE]]
+        and where all <a data-cite="i18n-glossary#dfn-code-point">code points</a> MUST be
+        <a data-cite="i18n-glossary#dfn-scalar-value">Unicode scalar values</a>
+        (i.e., not include <a data-cite="i18n-glossary#dfn-surrogate">surrogate code points</a>).</li>
       <li>a <dfn>datatype IRI</dfn>, being an <a>IRI</a>
         identifying a datatype that determines how the lexical form maps
         to a <a>literal value</a>, and</li>
@@ -978,7 +980,7 @@
     a <a>value space</a> and a <a>lexical-to-value mapping</a>, and
     is denoted by one or more <a>IRIs</a>.</p>
 
-  <p>The <dfn>lexical space</dfn> of a datatype is a set of Unicode [[!UNICODE]] strings.</p>
+  <p>The <dfn>lexical space</dfn> of a datatype is a set of unicode strings [[!UNICODE]].</p>
 
   <p>The <dfn>lexical-to-value mapping</dfn> of a datatype is a set of
     pairs whose first element belongs to the <a>lexical space</a>,
@@ -1061,7 +1063,7 @@
       <caption>A list of the RDF-compatible XSD types, with short descriptions</caption>
       <tr><th></th><th>Datatype</th><th>Value space (informative)</th></tr>
 
-      <tr><th rowspan="4">Core types</th><td><a data-cite="xmlschema11-2#string"><code>xsd:string</code></a></td><td>Character strings (but not all Unicode character strings)</td></tr>
+      <tr><th rowspan="4">Core types</th><td><a data-cite="xmlschema11-2#string"><code>xsd:string</code></a></td><td>Character strings (but not all unicode strings [[UNICODE]])</td></tr>
       <tr><td><a data-cite="xmlschema11-2#boolean"><code>xsd:boolean</code></a></td><td>true, false</td></tr>
       <tr><td><a data-cite="xmlschema11-2#decimal"><code>xsd:decimal</code></a></td><td>Arbitrary-precision decimal numbers</td></tr>
       <tr><td><a data-cite="xmlschema11-2#integer"><code>xsd:integer</code></a></td><td>Arbitrary-size integer numbers</td></tr>
@@ -1220,7 +1222,7 @@
       <dd>is <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML</code>.</dd>
 
       <dt>The lexical space</dt>
-      <dd>is the set of Unicode [[UNICODE]] strings.</dd>
+      <dd>is the set of unicode strings [[!UNICODE]].</dd>
 
       <dt>The value space</dt>
       <dd>is a set of DOM
@@ -1646,6 +1648,7 @@
       and definitions for <a>quoted triple</a> and <a>asserted triple</a>.</li>
     <li>Changed reference from DOM4, which was not a recommendation at the time, to [[DOM]],
       making the <a>rdf:HTML</a> and <a>rdf:XMLLiteral</a> datatypes normative.</li>
+    <li>Clarify Unicode terminology.</li>
   </ul>
 
   <p class="note">A detailed overview of the differences between RDF versions&nbsp;1.0

--- a/spec/index.html
+++ b/spec/index.html
@@ -505,7 +505,7 @@
     <p>RDF uses Unicode [[Unicode]] as the fundamental representation for string values.
       Within this, and related specifications, the term <dfn id="dfn-rdf-string">string</dfn>,
       or <a data-lt="string">RDF string</a>,
-      `is used to describe an ordered` sequence of zero or more
+      is used to describe an ordered sequence of zero or more
       <a data-lt="code point" class="lint-ignore">Unicode code points</a>
       which are <a data-cite="i18n-glossary#dfn-scalar-value" class="lint-ignore">Unicode scalar values</a>.
       Unicode scalar values do not include the

--- a/spec/index.html
+++ b/spec/index.html
@@ -1084,7 +1084,7 @@
       <caption>A list of the RDF-compatible XSD types, with short descriptions</caption>
       <tr><th></th><th>Datatype</th><th>Value space (informative)</th></tr>
 
-      <tr><th rowspan="4">Core types</th><td><a data-cite="xmlschema11-2#string"><code>xsd:string</code></a></td><td>Character strings (see <a>string</a>)</td></tr>
+      <tr><th rowspan="4">Core types</th><td><a data-cite="xmlschema11-2#string"><code>xsd:string</code></a></td><td>Character strings</td></tr>
       <tr><td><a data-cite="xmlschema11-2#boolean"><code>xsd:boolean</code></a></td><td>true, false</td></tr>
       <tr><td><a data-cite="xmlschema11-2#decimal"><code>xsd:decimal</code></a></td><td>Arbitrary-precision decimal numbers</td></tr>
       <tr><td><a data-cite="xmlschema11-2#integer"><code>xsd:integer</code></a></td><td>Arbitrary-size integer numbers</td></tr>

--- a/spec/index.html
+++ b/spec/index.html
@@ -502,18 +502,17 @@
 
     <p>RDF uses Unicode [[Unicode]] as the fundamental representation for string values.
       Within this, and related specifications, the term <dfn id="dfn-rdf-string">string</dfn>
-      is used to describe an ordered sequence of zero or more <a data-lt="code point" class="lint-ignore">Unicode code points</a>
+      is used to describe an ordered sequence of zero or more <a data-lt="code point" class="lint-ignore">Unicode code points</a> which are <a data-cite="i18n-glossary#dfn-scalar-value" class="lint-ignore">Unicode scalar values</a>, which do not include Unicode surrogate code points.
       in any <a data-cite="i18n-glossary#dfn-character-encoding">character encoding</a>.
       Note that most <a>concrete RDF syntaxes</a> require the use
       of the UTF-8 character encoding [[!RFC3629]], 
       which requires that certain non-character values be expressed
       using the `\u0000` or `\U00000000` forms.
-      are restricted to the UTF-8 character encoding [[!RFC3629]].
 </p>
 
     <p>A string is identical to another string if it consists of the same sequence of code points.
       An implementation MAY determine string equality by comparing the <a data-cite="i18n-glossary#dfn-code-unit">code units</a> of two strings
-      using the same <a data-cite="i18n-glossary#dfn-character-encoding">Unicode character encoding</a> form
+      that use the same <a data-cite="i18n-glossary#dfn-character-encoding">Unicode character encoding</a>
       (UTF-8 or UTF-16) without decoding the string into a <a data-lt="code point" class="lint-ignore">Unicode code point</a> sequence.</p>
   </section>
 </section>
@@ -696,8 +695,7 @@
     <ul>
       <li>a <dfn>lexical form</dfn> consisting of a sequence of
         <a data-lt="code point" class="lint-ignore">Unicode code points</a> [[!UNICODE]]
-        matching the <a data-cite="XML11#charsets">Char</a> production [[XML11]].
-       Because RDF lexical forms match the Char production of XML they do not contain Unicode surrogate code points.</li>
+        which are <a data-cite="i18n-glossary#dfn-scalar-value">Unicode scalar values</a>, thus, they do not contain Unicode surrogate code points.</li>
       <li>a <dfn>datatype IRI</dfn>, being an <a>IRI</a>
         identifying a datatype that determines how the lexical form maps
         to a <a>literal value</a>, and</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -501,7 +501,8 @@
     <h2>Strings in RDF</h2>
 
     <p>RDF uses Unicode [[Unicode]] as the fundamental representation for string values.
-      Within this, and related specifications, the term <dfn id="dfn-rdf-string">string</dfn>
+      Within this, and related specifications, the term <dfn id="dfn-rdf-string">string</dfn>,
+      or <a data-lt="string">RDF string</a>,
       is used to describe an ordered sequence of zero or more <a data-lt="code point" class="lint-ignore">Unicode code points</a> which are <a data-cite="i18n-glossary#dfn-scalar-value" class="lint-ignore">Unicode scalar values</a>, which do not include Unicode surrogate code points.
       in any <a data-cite="i18n-glossary#dfn-character-encoding">character encoding</a>.
       Note that most <a>concrete RDF syntaxes</a> require the use

--- a/spec/index.html
+++ b/spec/index.html
@@ -576,7 +576,7 @@
 
     <p>An <dfn data-lt="iri"><abbr title="Internationalized Resource Identifier">IRI</abbr></dfn>
       (Internationalized Resource Identifier) within an RDF graph
-      is a unicode string [[!UNICODE]] that conforms to the syntax
+      is a Unicode string [[!UNICODE]] that conforms to the syntax
       defined in RFC 3987 [[!RFC3987]].</p>
 
     <p class="note">For convenience, a complete [[ABNF]] grammar
@@ -587,7 +587,7 @@
 
     <p><dfn>IRI equality</dfn>:
       Two IRIs are the same if and only if they compare as identical when
-      considered as character strings (unicode strings), as in Simple String Comparison in
+      considered as character strings (Unicode strings), as in Simple String Comparison in
       <a data-cite="rfc3987#section-5.3.1">section 5.3.1</a>
       of [[!RFC3987]].
       (This is done in the abstract syntax, so the IRIs are absolute
@@ -672,7 +672,7 @@
       elements:</p>
 
     <ul>
-      <li>a <dfn>lexical form</dfn>, being a unicode string [[!UNICODE]],
+      <li>a <dfn>lexical form</dfn>, being a Unicode string [[!UNICODE]],
         which SHOULD be in <a data-cite="i18n-glossary#dfn-unicode-normalization-form-c">Normalization Form&nbsp;C</a> [[!UNICODE]]
         and where all <a data-cite="i18n-glossary#dfn-code-point">code points</a> MUST be
         <a data-cite="i18n-glossary#dfn-scalar-value">Unicode scalar values</a>
@@ -981,7 +981,7 @@
     a <a>value space</a> and a <a>lexical-to-value mapping</a>, and
     is denoted by one or more <a>IRIs</a>.</p>
 
-  <p>The <dfn>lexical space</dfn> of a datatype is a set of unicode strings [[!UNICODE]].</p>
+  <p>The <dfn>lexical space</dfn> of a datatype is a set of Unicode strings [[!UNICODE]].</p>
 
   <p>The <dfn>lexical-to-value mapping</dfn> of a datatype is a set of
     pairs whose first element belongs to the <a>lexical space</a>,
@@ -1064,7 +1064,7 @@
       <caption>A list of the RDF-compatible XSD types, with short descriptions</caption>
       <tr><th></th><th>Datatype</th><th>Value space (informative)</th></tr>
 
-      <tr><th rowspan="4">Core types</th><td><a data-cite="xmlschema11-2#string"><code>xsd:string</code></a></td><td>Character strings (but not all unicode strings [[UNICODE]])</td></tr>
+      <tr><th rowspan="4">Core types</th><td><a data-cite="xmlschema11-2#string"><code>xsd:string</code></a></td><td>Character strings (but not all Unicode strings [[UNICODE]])</td></tr>
       <tr><td><a data-cite="xmlschema11-2#boolean"><code>xsd:boolean</code></a></td><td>true, false</td></tr>
       <tr><td><a data-cite="xmlschema11-2#decimal"><code>xsd:decimal</code></a></td><td>Arbitrary-precision decimal numbers</td></tr>
       <tr><td><a data-cite="xmlschema11-2#integer"><code>xsd:integer</code></a></td><td>Arbitrary-size integer numbers</td></tr>
@@ -1223,7 +1223,7 @@
       <dd>is <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML</code>.</dd>
 
       <dt>The lexical space</dt>
-      <dd>is the set of unicode strings [[!UNICODE]].</dd>
+      <dd>is the set of Unicode strings [[!UNICODE]].</dd>
 
       <dt>The value space</dt>
       <dd>is a set of DOM
@@ -1278,7 +1278,7 @@
       <dd>is <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral</code>.</dd>
 
       <dt id="XMLLiteral-lexical-space">The <a>lexical space</a></dt>
-      <dd>is the set of all strings which are well-balanced, self-contained
+      <dd>is the set of all Unicode strings [[UNICODE]] which are well-balanced, self-contained
         <a data-cite="XML10#NT-content">XML content</a>
         [[XML10]]; and for which embedding between an arbitrary
         XML start tag and an end tag yields a document conforming to
@@ -1494,12 +1494,12 @@
 
 <section id="internationalization" class="appendix informative">
   <h2>Internationalization Considerations</h2>
-  <p>RDF is restricted to representing string values with left-to-right or right-to-left direction indicators.
+  <p>RDF is restricted to representing Unicode string [[UNICODE]] values with left-to-right or right-to-left direction indicators.
     RDF provides a mechanism for specifying the language associated with
     a string (<a>language-tagged string</a>),
     but does not provide a means of indicating the base direction of the string.</p>
 
-  <p>Unicode provides a mechanism for signaling direction within a string
+  <p>Unicode [[UNICODE]] provides a mechanism for signaling direction within a string
     (see [[[UAX9]]] [[UAX9]]),
     however, when a string has an overall base direction which cannot be determined by the
     beginning of the string, an external indicator is required,


### PR DESCRIPTION
This tries to improve our use of Unicode terminology. Note that there is no good referencable term for "unicode string" other than [[UNICODE]]. The RDF Literal definition is updated to exclude surrogate code points by referencing "unicode scalar value", which is a normative change.

Most of the Unicode-specific terminology comes from [i18n-glossary](https://w3c.github.io/i18n-glossary).

Fixes #51.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/59.html" title="Last updated on Sep 12, 2023, 9:27 AM UTC (a6bcd68)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/59/e4b1b92...a6bcd68.html" title="Last updated on Sep 12, 2023, 9:27 AM UTC (a6bcd68)">Diff</a>