### PR TITLE
Moves datatype definitions to an appendix and adds rdf:JSON datatype

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1498,7 +1498,7 @@
         in order to avoid side effects with existing specifications.
       </dd>
 
-      <dt id="JSON-mapping>The <a>lexical-to-value mapping</a></dt>
+      <dt id="JSON-mapping">The <a>lexical-to-value mapping</a></dt>
       <dd>
         maps every element of the lexical space to the result of
         <ol>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1249,7 +1249,7 @@
     The semantics of fragment identifiers is
     <a data-cite="rfc3986#section-3.5">defined in
     RFC 3986</a> [[RFC3986]]: They identify a secondary resource
-    that is usually a part of, view of, defined in, or described in
+    that is usually a part of, a view of, defined in, or described in
     the primary resource, and the precise semantics depend on the set
     of representations that might result from a retrieval action
     on the primary resource.</p>
@@ -1257,11 +1257,11 @@
   <p>This section discusses the handling of fragment identifiers
     in representations that encode <a>RDF graphs</a>.</p>
 
-  <p>In RDF-bearing representations of a primary resource
-    <code>&lt;foo&gt;</code>,
-    the secondary resource identified by a fragment <code>bar</code>
+  <p>In RDF-bearing representations of a primary resource,
+    <code>&lt;https://example.com/foo&gt;</code>,
+    the secondary resource identified by a fragment identifier, <code>bar</code>,
     is the <a>resource</a> <a>denoted</a> by the
-    full <a>IRI</a> <code>&lt;foo#bar&gt;</code> in the <a>RDF graph</a>.
+    full <a>IRI</a> <code>&lt;https://example.com/foo#bar&gt;</code> in the <a>RDF graph</a>.
     Since IRIs in RDF graphs can denote anything, this can be
     something external to the representation, or even external
     to the web.</p>
@@ -1274,7 +1274,7 @@
     <a>fragment identifiers</a> in RDF-bearing representations, the encoded
     <a>RDF graph</a> should use fragment identifiers in a way that is consistent
     with these constraints. For example, in an HTML+RDFa document [[HTML-RDFA]],
-    the fragment <code>chapter1</code> may identify a document section
+    a fragment identifier such as <code>chapter1</code> may identify a document section
     via the semantics of HTML's <code>@name</code> or <code>@id</code>
     attributes. The <a>IRI</a> <code>&lt;#chapter1&gt;</code> should
     then be taken to <a>denote</a> that same section in any RDFa-encoded
@@ -1282,7 +1282,7 @@
     Similarly, fragment identifiers should be used consistently in resources
     with multiple representations that are made available via
     <a data-cite="webarch/#frag-coneg">content negotiation</a>
-    [[WEBARCH]]. For example, if the fragment <code>chapter1</code> identifies a
+    [[WEBARCH]]. For example, if the fragment identifier <code>chapter1</code> identifies a
     document section in an HTML representation of the primary resource, then the
     <a>IRI</a> <code>&lt;#chapter1&gt;</code> should be taken to
     <a>denote</a> that same section in all RDF-bearing representations of the
@@ -1293,19 +1293,19 @@
   <h2>Generalized RDF Triples, Graphs, and Datasets</h2>
 
   <p>It is sometimes convenient to loosen the requirements
-    on <a>RDF triple</a>s.  For example, the completeness
+    on <a>RDF triples</a>.  For example, the completeness
     of the RDFS entailment rules is easier to show with a
     generalization of RDF triples.</p>
 
   <p>A <dfn class="export">generalized RDF triple</dfn> is a triple having a subject,
-    a predicate, and object, where each can be an <a>IRI</a>, a
+    a predicate, and an object, where each can be an <a>IRI</a>, a
     <a>blank node</a> or a
     <a>literal</a>. A
     <dfn class="export">generalized RDF graph</dfn>
     is a set of generalized RDF triples. A
     <dfn class="export">generalized RDF dataset</dfn>
     comprises a distinguished generalized RDF graph, and zero
-    or more pairs each associating an IRI, a blank node or a literal
+    or more pairs each associating an IRI, a blank node, or a literal
     to a generalized RDF graph.</p>
 
 
@@ -1314,14 +1314,14 @@
     <a data-lt="RDF graph">graphs</a>, and
     <a data-lt="RDF dataset">datasets</a> only
     by allowing <a>IRIs</a>,
-    <a>blank nodes</a> and
+    <a>blank nodes</a>, and
     <a>literals</a> to appear
-    in any position, i.e., as subject, predicate, object or graph names.</p>
+    in any position, i.e., as subject, predicate, object, or graph name.</p>
 
-  <p class="note" id="note-generalized-rdf"> Any users of
-    generalized RDF triples, graphs or datasets need to be
+  <p class="note" id="note-generalized-rdf">Any user of
+    generalized RDF triples, graphs, or datasets needs to be
     aware that these notions are non-standard extensions of
-    RDF and their use may cause interoperability problems.
+    RDF, and their use may cause interoperability problems.
     There is no requirement on the part of any RDF tool to
     accept, process, or produce anything beyond standard RDF
     triples, graphs, and datasets. </p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -33,7 +33,7 @@
         { name: "Brian McBride" }
       ],
 
-      xref: ["i18n-glossary"],
+      xref: ["i18n-glossary", "infra"],
       github: "https://github.com/w3c/rdf-concepts/",
       group:           "rdf-star",
       doJsonLd:     true,
@@ -140,7 +140,7 @@
     <dfn data-lt="resource">resources</dfn>. Anything can be a resource,
     including physical things, documents, abstract concepts, numbers
     and strings; the term is synonymous with "entity" as it is used in
-    the RDF Semantics specification [[RDF12-SEMANTICS]].
+    [[[RDF12-SEMANTICS]]] [[RDF12-SEMANTICS]].
     The resource denoted by an IRI is called its <a>referent</a>, and the
     resource denoted by a literal is called its
     <a>literal value</a>. Literals have
@@ -407,7 +407,7 @@
       simple <dfn class="export">logical expression</dfn>, or claim about the world.
       An <a>RDF graph</a> is the conjunction (logical <em>AND</em>) of
       its triples.   The precise details of this meaning of RDF triples and graphs are
-      the subject of the RDF Semantics specification [[RDF12-SEMANTICS]], which yields the
+      the subject of [[[RDF12-SEMANTICS]]] [[RDF12-SEMANTICS]], which yields the
       following relationships between <a>RDF graph</a>s:</p>
 
     <dl>
@@ -506,7 +506,7 @@
       Within this, and related specifications, the term <dfn id="dfn-rdf-string">string</dfn>,
       or <a data-lt="string">RDF string</a>,
       is used to describe an ordered sequence of zero or more
-      <a data-lt="code point" class="lint-ignore">Unicode code points</a>
+      <a data-cite="i18n-glossary#dfn-code-point" class="lint-ignore">Unicode code points</a>
       which are <a data-cite="i18n-glossary#dfn-scalar-value" class="lint-ignore">Unicode scalar values</a>.
       Unicode scalar values do not include the
       <a data-cite="i18n-glossary#dfn-surrogate" class="lint-ignore">surrogate code points</a>.
@@ -520,7 +520,7 @@
       <a data-cite="i18n-glossary#dfn-code-unit">code units</a> of two strings
       that use the same <a data-cite="i18n-glossary#dfn-character-encoding">Unicode character encoding</a>
       (UTF-8 or UTF-16) without decoding the string into a
-      <a data-lt="code point" class="lint-ignore">Unicode code point</a> sequence.</p>
+      <a data-cite="i18n-glossary#dfn-code-point" class="lint-ignore">Unicode code point</a> sequence.</p>
   </section>
 </section>
 
@@ -615,7 +615,7 @@
 
     <p><dfn>IRI equality</dfn>:
       Two IRIs are the same if and only if they consist of the same sequence of
-      <a data-lt="code point" class="lint-ignore">Unicode code points</a>,
+      <a data-cite="i18n-glossary#dfn-code-point" class="lint-ignore">Unicode code points</a>,
       as in Simple String Comparison in
       <a data-cite="rfc3987#section-5.3.1">section 5.3.1</a> of [[!RFC3987]].
       (This is done in the abstract syntax, so the IRIs are resolved
@@ -701,7 +701,7 @@
 
     <ul>
       <li>a <dfn>lexical form</dfn> consisting of a sequence of
-        <a data-lt="code point" class="lint-ignore">Unicode code points</a> [[!UNICODE]]
+        <a data-cite="i18n-glossary#dfn-code-point" class="lint-ignore">Unicode code points</a> [[!UNICODE]]
         which are <a data-cite="i18n-glossary#dfn-scalar-value">Unicode scalar values</a>,
         and therefore do not contain
         <a data-cite="i18n-glossary#dfn-surrogate" class="lint-ignore">Unicode surrogate code points</a>.</li>
@@ -1002,7 +1002,7 @@
     [[!XMLSCHEMA11-2]]. Any datatype definition that conforms
     to this abstraction MAY be used in RDF, even if not defined
     in terms of XML Schema. RDF re-uses many of the XML Schema
-    built-in datatypes, and defines two additional non-normative datatypes,
+    built-in datatypes, and defines three additional datatypes,
     <code><a>rdf:JSON</a></code>, <code><a>rdf:HTML</a></code>, and <code><a>rdf:XMLLiteral</a></code>.
     The list of datatypes supported by an implementation is determined
     by its <a>recognized datatype IRIs</a>.</p>
@@ -1086,7 +1086,7 @@
       listed in the following table are the
       <dfn>RDF-compatible XSD types</dfn>. Their use is RECOMMENDED.</p>
 
-    <p>Readers might note that the xsd:hexBinary and xsd:base64Binary
+    <p>Readers might note that the `xsd:hexBinary` and `xsd:base64Binary`
       datatypes are the only safe datatypes for transferring binary
       information.</p>
 
@@ -1223,8 +1223,8 @@
 
     <p class="note">Semantic extensions of RDF might choose to
       recognize other datatype IRIs
-      and require them to refer to a fixed datatype.  See the RDF
-      Semantics specification [[RDF12-SEMANTICS]] for more information on
+      and require them to refer to a fixed datatype.
+      See [[[RDF12-SEMANTICS]]] [[RDF12-SEMANTICS]] for more information on
       semantic extensions.</p>
 
     <p class="note" id="note-custom-datatypes">The Web Ontology Language
@@ -1460,60 +1460,56 @@
       <dd>is <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON</code>.</dd>
 
       <dt id="JSON-lexical-space">The <a>lexical space</a></dt>
-      <dd>is the set of all UNICODE [[UNICODE]] strings that conform to the
+      <dd>is the set of all <a>strings</a> that conform to the
         <a data-cite="RFC4627#section-2">JSON Grammar</a> as described in
         <a data-cite="RFC8259#section-2">Section&nbsp;2 JSON Grammar</a> of
         [[RFC8259]].</dd>
 
       <dt id="JSON-value-space">The <a>value space</a></dt>
       <dd>
-        is the set of all UNICODE [[UNICODE]] strings that conform to the
-        <a data-cite="RFC4627#section-2">JSON Grammar</a> as described in
-        <a data-cite="RFC8259#section-2">Section&nbsp;2 JSON Grammar</a> of
-        [[RFC8259]], and furthermore comply with the following constraints:
+        is the space defined by
+        the <a data-cite="JSON-LD11#dfn-internal-representation">JSON-LD internal representation</a> [[JSON-LD11]],
+        being the <a data-cite="RFC4627#section-3">JSON values</a> <a data-lt="list">array</a>,
+        <a>map</a>,
+        <a>string</a>,
+        <a data-cite="ECMASCRIPT#sec-terms-and-definitions-number-value">number</a>,
+        <a>boolean</a>, or
+        <a data-cite="INFRA#nulls">null</a>.
         <ul>
-          <li>They MUST NOT contain any unnecessary whitespace.</li>
-          <li>Keys in objects MUST be ordered lexicographically.</li>
-          <li>Native Numeric values MUST be serialized according to
-            <a data-cite="ECMASCRIPT#sec-tostring-applied-to-the-number-type">Section&nbsp;7.1.12.1</a>
-            of [[ECMASCRIPT]].</li>
-          <li>Strings MUST be serialized with Unicode codepoints from `U+0000`
-            through `U+001F` using lower case hexadecimal Unicode notation
-            (`\uhhhh`) except for the set of predefined JSON control characters —
-            `U+0008`, `U+0009`, `U+000A`, `U+000C`, and `U+000D` — which SHOULD be
-            serialized as `\b`, `\t`, `\n`, `\f`, and `\r`, respectively. All
-            other Unicode characters SHOULD be serialized "as is", except
-            `U+005C` (`\`) and `U+0022` (`"`), which SHOULD be serialized as
-            `\\` and `\"`, respectively.</li>
+          <li><a data-lt="list">Array</a> <a data-cite="INFRA#list-item">entries</a> may be
+            <a>map</a>,
+            <a>string</a>,
+            <a data-cite="ECMASCRIPT#sec-terms-and-definitions-number-value">number</a>,
+            <a>boolean</a>, or
+            <a data-cite="INFRA#nulls">null</a>.</li>
+          <li><a>Map</a> <a data-cite="INFRA#map-key">keys</a> are <a>strings</a> with
+            <a data-cite="INFRA#map-value">values</a> may be any of the above
+            <a data-cite="RFC4627#section-3">JSON values</a>.</li>
         </ul>
-        <div class="issue">The JSON Canonicalization Scheme (JCS) [[RFC8785]]
-          is an emerging standard for JSON canonicalization. This <code>rdf:JSON</code> specification
-          will likely be updated to require such a canonical representation.
-          Users are cautioned against depending on the lexical representation of
-          literals with the <code>rdf:JSON</code> datatype as RDF literals,
-          as the specifics of serialization may change in a future revision of
-          this document.</div>
-        Despite being defined as a set of strings, this value space is
-        considered distinct from the value space of <code>xsd:string</code>,
-        in order to avoid side effects with existing specifications.
+
+        Two <a data-cite="RFC4627#section-3">JSON values</a> are considered equal
+        if they are the same if they are the same <a>string</a>,
+        <a data-cite="ECMASCRIPT#sec-terms-and-definitions-number-value">number</a>,
+        <a>boolean</a>, or
+        <a data-cite="INFRA#nulls">null</a>,
+        if they are both an <a data-lt="list">array</a> with equal <a data-cite="INFRA#list-item">entries</a>, or
+        if they are both a <a>map</a> with equal <a data-cite="INFRA#map-entry">map entries</a>.
       </dd>
 
       <dt id="JSON-mapping">The <a>lexical-to-value mapping</a></dt>
       <dd>
-        maps every element of the lexical space to the result of
-        <ol>
-          <li>parsing it into an internal representation consistent with the
-            [[ECMASCRIPT]] representation created by using the <code>JSON.parse</code>
-            function as defined in <a data-cite="ECMASCRIPT#sec-json-object">Section&nbsp;24.5 The JSON Object</a>
-            of [[ECMASCRIPT]],</li>
-          <li>then serializing it into the JSON format [[RFC8259]] in compliance
-            with the constraints of the value space described above.</li>
-        </ol>
+        maps every element of the lexical space to the result of parsing it into an
+        <a data-cite="JSON-LD11#dfn-internal-representation">internal representation</a>
+        consistent with the [[ECMASCRIPT]] representation created by using the <code>JSON.parse</code>
+        function as defined in <a data-cite="ECMASCRIPT#sec-json-object">Section&nbsp;24.5 The JSON Object</a>
+        of [[ECMASCRIPT]].
       </dd>
 
       <dt id="JSON-canonical">The canonical mapping</dt>
-      <dd>maps any element of the value space to the identical string in the
-        lexical space.</dd>
+      <dd>maps the <a data-cite="JSON-LD11#dfn-internal-representation">internal representation</a>
+        to a <a>string</a> conforming to the <a data-cite="RFC4627#section-2">JSON Grammar</a>
+        using the mechanism described in [[[RFC8785]] [[RFC8785]].
+      </dd>
     </dl>
   </section>
 
@@ -1758,7 +1754,7 @@
       from <a data-cite="?JSON-LD11#the-rdf-json-datatype">Section&nbsp;10.2 The `rdf:JSON` Datatype</a>
       in [[?JSON-LD11]].</li>
     <li>Clarify Unicode terminology,
-      using <a data-lt="code point" class="lint-ignore">Unicode code points</a>,
+      using <a data-cite="i18n-glossary#dfn-code-point" class="lint-ignore">Unicode code points</a>,
       and restriction to the XML <a data-cite="XML11#charsets">Char</a> production.
       Also removes obsolete recommendations for the use of Normalization Form C in literals.
       Adds a definition of <a>string</a> that can be used in other RDF documents.</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1199,7 +1199,8 @@
       MUST refer to the RDF-compatible XSD type named <code>xsd:xxx</code> for
       every XSD type listed in <a href="#xsd-datatypes">section 5.1</a>.</p>
 
-    <p>The following three datatype IRIs are defined in Appendix&nbsp;<a href="#section-additional-datatypes" class="sectionRef"></a>:</p>
+    <p>The datatypes identified by the three IRIs below are defined in
+    Appendix&nbsp;<a href="#section-additional-datatypes" class="sectionRef"></a>:</p>
 
     <ul>
       <li>The IRI <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral</code>
@@ -1257,11 +1258,11 @@
   <p>This section discusses the handling of fragment identifiers
     in representations that encode <a>RDF graphs</a>.</p>
 
-  <p>In RDF-bearing representations of a primary resource,
+  <p>In RDF-bearing representations of a primary resource, e.g.,
     <code>&lt;https://example.com/foo&gt;</code>,
-    the secondary resource identified by a fragment identifier, <code>bar</code>,
+    the secondary resource identified by a fragment identifier, e.g., <code>bar</code>,
     is the <a>resource</a> <a>denoted</a> by the
-    full <a>IRI</a> <code>&lt;https://example.com/foo#bar&gt;</code> in the <a>RDF graph</a>.
+    full <a>IRI</a> in the <a>RDF graph</a>, which would be <code>&lt;https://example.com/foo#bar&gt;</code> in this case.
     Since IRIs in RDF graphs can denote anything, this can be
     something external to the representation, or even external
     to the web.</p>
@@ -1276,7 +1277,7 @@
     with these constraints. For example, in an HTML+RDFa document [[HTML-RDFA]],
     a fragment identifier such as <code>chapter1</code> may identify a document section
     via the semantics of HTML's <code>@name</code> or <code>@id</code>
-    attributes. The <a>IRI</a> <code>&lt;#chapter1&gt;</code> should
+    attributes. Such an <a>IRI</a>, e.g., <code>&lt;#chapter1&gt;</code>, should
     then be taken to <a>denote</a> that same section in any RDFa-encoded
     <a>triples</a> within the same document.
     Similarly, fragment identifiers should be used consistently in resources
@@ -1322,7 +1323,7 @@
     generalized RDF triples, graphs, or datasets needs to be
     aware that these notions are non-standard extensions of
     RDF, and their use may cause interoperability problems.
-    There is no requirement on the part of any RDF tool to
+    There is no requirement for any RDF tool to
     accept, process, or produce anything beyond standard RDF
     triples, graphs, and datasets. </p>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -1462,14 +1462,14 @@
 
       <dt id="JSON-lexical-space">The <a>lexical space</a></dt>
       <dd>is the set of all <a data-lt="string">RDF strings</a> that conform to the
-        <a data-cite="RFC4627#section-2">JSON Grammar</a> as described in
+        <a data-cite="RFC8259#section-2">JSON Grammar</a> as described in
         <a data-cite="RFC8259#section-2">Section&nbsp;2 JSON Grammar</a> of
         [[RFC8259]].</dd>
 
       <dt id="JSON-value-space">The <a>value space</a></dt>
       <dd>
         is the set of all <a data-lt="string">RDF strings</a> that conform to the
-        <a data-cite="RFC4627#section-2">JSON Grammar</a> as described in
+        <a data-cite="RFC8259#section-2">JSON Grammar</a> as described in
         <a data-cite="RFC8259#section-2">Section&nbsp;2 JSON Grammar</a> of
         [[RFC8259]], and furthermore comply with the following constraints:
         <ul>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1467,9 +1467,7 @@
 
       <dt id="JSON-value-space">The <a>value space</a></dt>
       <dd>
-        is the space defined by
-        the <a data-cite="JSON-LD11#dfn-internal-representation">JSON-LD internal representation</a> [[JSON-LD11]],
-        being the <a data-cite="RFC4627#section-3">JSON values</a> <a data-lt="list">array</a>,
+        is a single <a data-cite="RFC4627#section-3">JSON value</a> in the form of an <a data-lt="list">array</a>,
         <a>map</a>,
         <a>string</a>,
         <a data-cite="ECMASCRIPT#sec-terms-and-definitions-number-value">number</a>,
@@ -1498,15 +1496,15 @@
 
       <dt id="JSON-mapping">The <a>lexical-to-value mapping</a></dt>
       <dd>
-        maps every element of the lexical space to the result of parsing it into an
-        <a data-cite="JSON-LD11#dfn-internal-representation">internal representation</a>
+        maps every element of the lexical space to the result of parsing it into a
+        <a data-cite="RFC4627#section-3">JSON value</a>
         consistent with the [[ECMASCRIPT]] representation created by using the <code>JSON.parse</code>
         function as defined in <a data-cite="ECMASCRIPT#sec-json-object">Section&nbsp;24.5 The JSON Object</a>
         of [[ECMASCRIPT]].
       </dd>
 
       <dt id="JSON-canonical">The canonical mapping</dt>
-      <dd>maps the <a data-cite="JSON-LD11#dfn-internal-representation">internal representation</a>
+      <dd>maps a <a data-cite="RFC4627#section-3">JSON value</a>
         to a <a>string</a> conforming to the <a data-cite="RFC4627#section-2">JSON Grammar</a>
         using the mechanism described in [[[RFC8785]] [[RFC8785]].
       </dd>
@@ -1752,7 +1750,10 @@
       datatypes to this appendix.</li>
     <li>Added the <a>rdf:JSON</a> datatype, the definition of which is adopted
       from <a data-cite="?JSON-LD11#the-rdf-json-datatype">Section&nbsp;10.2 The `rdf:JSON` Datatype</a>
-      in [[?JSON-LD11]].</li>
+      in [[?JSON-LD11]].
+      Note that the <a href="#JSON-value-space">value space</a> defined here
+      updates the <a>value space</a> of the
+      <a data-cite="JSON-LD11#the-rdf-json-datatype">`rdf:JSON`</a> datatype defined in [[[JSON-LD11]]] [[JSON-LD11]]</li>
     <li>Clarify Unicode terminology,
       using <a data-cite="i18n-glossary#dfn-code-point" class="lint-ignore">Unicode code points</a>,
       and restriction to the XML <a data-cite="XML11#charsets">Char</a> production.

--- a/spec/index.html
+++ b/spec/index.html
@@ -1445,14 +1445,76 @@
       in RDF/XML [[RDF12-XML]].</p>
   </section>
 
-  <section id="section-json" class="informative">
+  <section id="section-json">
     <h3>The <code>rdf:JSON</code> Datatype</h3>
 
-    <p class="issue" data-number="14">
-      The <code><dfn>rdf:JSON</dfn></code> datatype was originally defined in
-      <a data-cite="?JSON-LD11#the-rdf-json-datatype">Section 10.2 The `rdf:JSON` Datatype</a>
-      in [[?JSON-LD11]].
-    </p>
+    <p>RDF provides for JSON content as a possible <a>literal value</a>.
+      This allows markup in literal values. Such content is indicated in an
+      <a>RDF graph</a> using a <a>literal</a> whose <a>datatype</a> is set
+      to <code><dfn>rdf:JSON</dfn></code>.</p>
+
+    <p>The <code>rdf:JSON</code> datatype is defined as follows:</p>
+
+    <dl>
+      <dt>The IRI denoting this <a>datatype</a></dt>
+      <dd>is <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON</code>.</dd>
+
+      <dt>The <a>lexical space</a></dt>
+      <dd>is the set of all UNICODE [[UNICODE]] strings that conform to the
+        <a data-cite="RFC4627#section-2">JSON Grammar</a> as described in
+        <a data-cite="RFC8259#section-2">Section&nbsp;2 JSON Grammar</a> of
+        [[RFC8259]].</dd>
+
+      <dt id="XMLLiteral-value-space">The <a>value space</a></dt>
+      <dd>
+        is the set of all UNICODE [[UNICODE]] strings that conform to the
+        <a data-cite="RFC4627#section-2">JSON Grammar</a> as described in
+        <a data-cite="RFC8259#section-2">Section&nbsp;2 JSON Grammar</a> of
+        [[RFC8259]], and furthermore comply with the following constraints:
+        <ul>
+          <li>It MUST NOT contain any unnecessary whitespace,</li>
+          <li>Keys in objects MUST be ordered lexicographically,</li>
+          <li>Native Numeric values MUST be serialized according to
+            <a data-cite="ECMASCRIPT#sec-tostring-applied-to-the-number-type">Section&nbsp;7.1.12.1</a>
+            of [[ECMASCRIPT]],</li>
+          <li>Strings MUST be serialized with Unicode codepoints from `U+0000`
+            through `U+001F` using lower case hexadecimal Unicode notation
+            (`\uhhhh`) unless in the set of predefined JSON control characters
+            `U+0008`, `U+0009`, `U+000A`, `U+000C` or `U+000D` which SHOULD be
+            serialized as `\b`, `\t`, `\n`, `\f` and `\r`, respectively. All
+            other Unicode characters SHOULD be serialized "as is", other than
+            `U+005C` (`\`) and `U+0022` (`"`) which SHOULD be serialized as
+            `\\` and `\"`, respectively.</li>
+        </ul>
+        <div class="issue">The JSON Canonicalization Scheme (JCS) [[RFC8785]]
+          is an emerging standard for JSON canonicalization. This specification
+          will likely be updated to require such a canonical representation.
+          Users are cautioned from depending on the lexical representation of
+          literals with the <code>rdf:JSON</code> datatype as an RDF literal,
+          as the specifics of serialization may change in a future revision of
+          this document.</div>
+        Despite being defined as a set of strings, this value space is
+        considered distinct from the value space of <code>xsd:string</code>,
+        in order to avoid side effects with existing specifications.
+      </dd>
+
+      <dt>The <a>lexical-to-value mapping</a></dt>
+      <dd>
+        maps every element of the lexical space to the result of
+        <ol>
+          <li>parsing it into an internal representation consistent with the
+            [[ECMASCRIPT]] representation created by using the <code>JSON.parse</code>
+            function as defined in <a data-cite="ECMASCRIPT#sec-json-object">Section&nbsp;24.5 The JSON Object</a>
+            of [[ECMASCRIPT]],</li>
+          <li>then serializing it in the JSON format [[RFC8259]] in compliance
+            with the constraints of the value space described above.</li>
+        </ol>
+      </dd>
+
+      <dt id="XMLLiteral-canonical">The canonical mapping</dt>
+      <dd>maps any element of the value space to the identical string in the
+        lexical space.</dd>
+    </dl>
   </section>
 
 </section>
@@ -1692,6 +1754,9 @@
     <li>Added <a href="#section-additional-datatypes" class="sectionRef"></a>
       and moved the sections about the <a>rdf:HTML</a> and <a>rdf:XMLLiteral</a>
       datatypes to this appendix.</li>
+    <li>Added the <a>rdf:JSON</a> datatype, the definition of which is adopted
+      from <a data-cite="?JSON-LD11#the-rdf-json-datatype">Section&nbsp;10.2 The `rdf:JSON` Datatype</a>
+      in [[?JSON-LD11]].</li>
     <li>Clarify Unicode terminology,
       using <a data-lt="code point" class="lint-ignore">Unicode code points</a>,
       and restriction to the XML <a data-cite="XML11#charsets">Char</a> production.

--- a/spec/index.html
+++ b/spec/index.html
@@ -1003,7 +1003,7 @@
     to this abstraction MAY be used in RDF, even if not defined
     in terms of XML Schema. RDF re-uses many of the XML Schema
     built-in datatypes, and defines two additional non-normative datatypes,
-    <code><a>rdf:HTML</a></code> and <code><a>rdf:XMLLiteral</a></code>.
+    <code><a>rdf:JSON</a></code>, <code><a>rdf:HTML</a></code>, and <code><a>rdf:XMLLiteral</a></code>.
     The list of datatypes supported by an implementation is determined
     by its <a>recognized datatype IRIs</a>.</p>
 
@@ -1344,10 +1344,10 @@
     <p>The <code>rdf:HTML</code> datatype is defined as follows:</p>
 
     <dl>
-      <dt>The IRI denoting this datatype</dt>
+      <dt id="HTML-uri">The IRI denoting this datatype</dt>
       <dd>is <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML</code>.</dd>
 
-      <dt>The value space</dt>
+      <dt id="HTML-value-space">The <a>value space</a></dt>
       <dd>is a set of DOM
         <a data-cite="DOM#interface-documentfragment"><code>DocumentFragment</code></a>
         nodes [[DOM]]. Two
@@ -1357,7 +1357,7 @@
         <code><var>node</var>.{{Node/isEqualNode(otherNode)}}</code>
         [[DOM]] returns <code>true</code>.</dd>
 
-      <dt>The lexical-to-value mapping</dt>
+      <dt id="HTML-mapping">The lexical-to-value mapping</dt>
       <dd>
         <p>Each member of the lexical space is associated with the result
           of applying the following algorithm:</p>
@@ -1456,16 +1456,16 @@
     <p>The <code>rdf:JSON</code> datatype is defined as follows:</p>
 
     <dl>
-      <dt>The IRI denoting this <a>datatype</a></dt>
+      <dt id="JSON-uri">The IRI denoting this <a>datatype</a></dt>
       <dd>is <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON</code>.</dd>
 
-      <dt>The <a>lexical space</a></dt>
+      <dt id="JSON-lexical-space">The <a>lexical space</a></dt>
       <dd>is the set of all UNICODE [[UNICODE]] strings that conform to the
         <a data-cite="RFC4627#section-2">JSON Grammar</a> as described in
         <a data-cite="RFC8259#section-2">Section&nbsp;2 JSON Grammar</a> of
         [[RFC8259]].</dd>
 
-      <dt id="XMLLiteral-value-space">The <a>value space</a></dt>
+      <dt id="JSON-value-space">The <a>value space</a></dt>
       <dd>
         is the set of all UNICODE [[UNICODE]] strings that conform to the
         <a data-cite="RFC4627#section-2">JSON Grammar</a> as described in
@@ -1511,7 +1511,7 @@
         </ol>
       </dd>
 
-      <dt id="XMLLiteral-canonical">The canonical mapping</dt>
+      <dt id="JSON-canonical">The canonical mapping</dt>
       <dd>maps any element of the value space to the identical string in the
         lexical space.</dd>
     </dl>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1467,44 +1467,53 @@
 
       <dt id="JSON-value-space">The <a>value space</a></dt>
       <dd>
-        is a single <a data-cite="RFC4627#section-2.1">JSON value</a> in the form of an <a data-cite="INFRA#list">array</a>,
-        <a data-cite="INFRA#ordered-map">map</a>,
-        <a data-cite="INFRA#string">string</a>,
-        <a data-cite="ECMASCRIPT#sec-terms-and-definitions-number-value">number</a>,
-        <a data-cite="INFRA#boolean">boolean</a>, or
-        <a data-cite="INFRA#nulls">null</a>.
+        is the set of all <a data-lt="string">RDF strings</a> that conform to the
+        <a data-cite="RFC4627#section-2">JSON Grammar</a> as described in
+        <a data-cite="RFC8259#section-2">Section&nbsp;2 JSON Grammar</a> of
+        [[RFC8259]], and furthermore comply with the following constraints:
         <ul>
-          <li><a data-cite="INFRA#list">Array</a> <a data-cite="INFRA#list-item">entries</a> may be
-            any of the above <a data-cite="RFC4627#section-2.1">JSON values</a>.</li>
-          <li><a data-cite="INFRA#ordered-map">Map</a> <a data-cite="INFRA#map-key">keys</a> are <a data-cite="INFRA#string">strings</a> with
-            <a data-cite="INFRA#map-value">values</a>, which may be any of the above
-            <a data-cite="RFC4627#section-2.1">JSON values</a>.</li>
+          <li>They MUST NOT contain any unnecessary whitespace.</li>
+          <li>Keys in objects MUST be ordered lexicographically.</li>
+          <li>Native Numeric values MUST be serialized according to
+            <a data-cite="ECMASCRIPT#sec-tostring-applied-to-the-number-type">Section&nbsp;7.1.12.1</a>
+            of [[ECMASCRIPT]].</li>
+          <li>Strings MUST be serialized with Unicode code points from <code class="codepoint">U+0000</code>
+            through <code class="codepoint">U+001F</code> using lower case hexadecimal Unicode notation
+            (`\uhhhh`) except for the set of predefined JSON control characters —
+            `U+0008`, `U+0009`, `U+000A`, `U+000C`, and `U+000D` — which SHOULD be
+            serialized as `\b`, `\t`, `\n`, `\f`, and `\r`, respectively. All
+            other Unicode characters SHOULD be serialized "as is", except
+            `U+005C` (`\`) and `U+0022` (`"`), which SHOULD be serialized as
+            `\\` and `\"`, respectively.</li>
         </ul>
-
-        Two <a data-cite="RFC4627#section-2.1">JSON values</a> are considered equal
-        if they are the same <a data-cite="INFRA#string">string</a>,
-        <a data-cite="ECMASCRIPT#sec-terms-and-definitions-number-value">number</a>,
-        <a data-cite="INFRA#boolean">boolean</a>, or
-        <a data-cite="INFRA#nulls">null</a>;
-        if they are both <a data-cite="INFRA#list">arrays</a> with <a data-cite="INFRA#list-item">entries</a>
-        which are pairwise equal;
-        or if they are both <a data-cite="INFRA#ordered-map">maps</a> with equal <a data-cite="INFRA#map-entry">map entries</a>.
+        <div class="issue">The JSON Canonicalization Scheme (JCS) [[RFC8785]]
+          is an emerging standard for JSON canonicalization. This <code>rdf:JSON</code> specification
+          will likely be updated to require such a canonical representation.
+          Users are cautioned against depending on the lexical representation of
+          literals with the <code>rdf:JSON</code> datatype as RDF literals,
+          as the specifics of serialization may change in a future revision of
+          this document.</div>
+        Despite being defined as a set of strings, this value space is
+        considered distinct from the value space of <code>xsd:string</code>,
+        in order to avoid side effects with existing specifications.
       </dd>
-
+ 
       <dt id="JSON-mapping">The <a>lexical-to-value mapping</a></dt>
       <dd>
-        maps every element of the lexical space to the result of parsing it into a
-        <a data-cite="RFC4627#section-2.1">JSON value</a>
-        consistent with the [[ECMASCRIPT]] representation created by using the <code>JSON.parse</code>
-        function as defined in <a data-cite="ECMASCRIPT#sec-json-object">Section&nbsp;24.5 The JSON Object</a>
-        of [[ECMASCRIPT]].
+        maps every element of the lexical space to the result of
+         <ol>
+          <li>parsing it into an internal representation consistent with the
+            [[ECMASCRIPT]] representation created by using the <code>JSON.parse</code>
+            function as defined in <a data-cite="ECMASCRIPT#sec-json-object">Section&nbsp;24.5 The JSON Object</a>
+            of [[ECMASCRIPT]],</li>
+          <li>then serializing it into the JSON format [[RFC8259]] in compliance
+            with the constraints of the value space described above.</li>
+        </ol>
       </dd>
 
       <dt id="JSON-canonical">The canonical mapping</dt>
-      <dd>maps a <a data-cite="RFC4627#section-2.1">JSON value</a>
-        to an <a data-lt="string">RDF string</a> conforming to the <a data-cite="RFC4627#section-2">JSON Grammar</a>
-        using the mechanism described in [[[RFC8785]] [[RFC8785]].
-      </dd>
+      <dd>maps any element of the value space to the identical string in the
+        lexical space.</dd>
     </dl>
   </section>
 
@@ -1747,10 +1756,7 @@
       datatypes to this appendix.</li>
     <li>Added the <a>rdf:JSON</a> datatype, the definition of which is adopted
       from <a data-cite="?JSON-LD11#the-rdf-json-datatype">Section&nbsp;10.2 The `rdf:JSON` Datatype</a>
-      in [[?JSON-LD11]].
-      Note that the <a href="#JSON-value-space">value space</a> defined here
-      updates the <a>value space</a> of the
-      <a data-cite="JSON-LD11#the-rdf-json-datatype">`rdf:JSON`</a> datatype defined in [[[JSON-LD11]]] [[JSON-LD11]]</li>
+      in [[?JSON-LD11]].</li>
     <li>Clarify Unicode terminology,
       using <a data-cite="i18n-glossary#dfn-code-point" class="lint-ignore">Unicode code points</a>,
       and restriction to the XML <a data-cite="XML11#charsets">Char</a> production.

--- a/spec/index.html
+++ b/spec/index.html
@@ -1482,13 +1482,13 @@
         </ul>
 
         Two <a data-cite="RFC4627#section-2.1">JSON values</a> are considered equal
-        if they are the same if they are the same <a data-cite="INFRA#string">string</a>,
+        if they are the same <a data-cite="INFRA#string">string</a>,
         <a data-cite="ECMASCRIPT#sec-terms-and-definitions-number-value">number</a>,
         <a data-cite="INFRA#boolean">boolean</a>, or
-        <a data-cite="INFRA#nulls">null</a>,
+        <a data-cite="INFRA#nulls">null</a>;
         if they are both <a data-cite="INFRA#list">arrays</a> with <a data-cite="INFRA#list-item">entries</a>
-        which are pairwise equal,
-        or if they are both a <a data-cite="INFRA#ordered-map">map</a> with equal <a data-cite="INFRA#map-entry">map entries</a>.
+        which are pairwise equal;
+        or if they are both <a data-cite="INFRA#ordered-map">maps</a> with equal <a data-cite="INFRA#map-entry">map entries</a>.
       </dd>
 
       <dt id="JSON-mapping">The <a>lexical-to-value mapping</a></dt>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1449,8 +1449,8 @@
     <h3>The <code>rdf:JSON</code> Datatype</h3>
 
     <p>RDF provides for JSON content as a possible <a>literal value</a>.
-      This allows markup in literal values. Such content is indicated in an
-      <a>RDF graph</a> using a <a>literal</a> whose <a>datatype</a> is set
+      This includes allowing markup in literal values. Such content is indicated in an
+      <a>RDF graph</a> as a <a>literal</a> whose <a>datatype</a> is set
       to <code><dfn>rdf:JSON</dfn></code>.</p>
 
     <p>The <code>rdf:JSON</code> datatype is defined as follows:</p>
@@ -1472,25 +1472,25 @@
         <a data-cite="RFC8259#section-2">Section&nbsp;2 JSON Grammar</a> of
         [[RFC8259]], and furthermore comply with the following constraints:
         <ul>
-          <li>It MUST NOT contain any unnecessary whitespace,</li>
-          <li>Keys in objects MUST be ordered lexicographically,</li>
+          <li>They MUST NOT contain any unnecessary whitespace.</li>
+          <li>Keys in objects MUST be ordered lexicographically.</li>
           <li>Native Numeric values MUST be serialized according to
             <a data-cite="ECMASCRIPT#sec-tostring-applied-to-the-number-type">Section&nbsp;7.1.12.1</a>
-            of [[ECMASCRIPT]],</li>
+            of [[ECMASCRIPT]].</li>
           <li>Strings MUST be serialized with Unicode codepoints from `U+0000`
             through `U+001F` using lower case hexadecimal Unicode notation
-            (`\uhhhh`) unless in the set of predefined JSON control characters
-            `U+0008`, `U+0009`, `U+000A`, `U+000C` or `U+000D` which SHOULD be
-            serialized as `\b`, `\t`, `\n`, `\f` and `\r`, respectively. All
-            other Unicode characters SHOULD be serialized "as is", other than
-            `U+005C` (`\`) and `U+0022` (`"`) which SHOULD be serialized as
+            (`\uhhhh`) except for the set of predefined JSON control characters —
+            `U+0008`, `U+0009`, `U+000A`, `U+000C`, and `U+000D` — which SHOULD be
+            serialized as `\b`, `\t`, `\n`, `\f`, and `\r`, respectively. All
+            other Unicode characters SHOULD be serialized "as is", except
+            `U+005C` (`\`) and `U+0022` (`"`), which SHOULD be serialized as
             `\\` and `\"`, respectively.</li>
         </ul>
         <div class="issue">The JSON Canonicalization Scheme (JCS) [[RFC8785]]
-          is an emerging standard for JSON canonicalization. This specification
+          is an emerging standard for JSON canonicalization. This <code>rdf:JSON</code> specification
           will likely be updated to require such a canonical representation.
-          Users are cautioned from depending on the lexical representation of
-          literals with the <code>rdf:JSON</code> datatype as an RDF literal,
+          Users are cautioned against depending on the lexical representation of
+          literals with the <code>rdf:JSON</code> datatype as RDF literals,
           as the specifics of serialization may change in a future revision of
           this document.</div>
         Despite being defined as a set of strings, this value space is
@@ -1506,7 +1506,7 @@
             [[ECMASCRIPT]] representation created by using the <code>JSON.parse</code>
             function as defined in <a data-cite="ECMASCRIPT#sec-json-object">Section&nbsp;24.5 The JSON Object</a>
             of [[ECMASCRIPT]],</li>
-          <li>then serializing it in the JSON format [[RFC8259]] in compliance
+          <li>then serializing it into the JSON format [[RFC8259]] in compliance
             with the constraints of the value space described above.</li>
         </ol>
       </dd>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1086,9 +1086,8 @@
       listed in the following table are the
       <dfn>RDF-compatible XSD types</dfn>. Their use is RECOMMENDED.</p>
 
-    <p>Readers might note that the `xsd:hexBinary` and `xsd:base64Binary`
-      datatypes are the only safe datatypes for transferring binary
-      information.</p>
+    <p>Readers might note that the only safe datatypes for transferring
+      binary information are `xsd:hexBinary` and `xsd:base64Binary`.</p>
 
     <table id="tab-xsd-datatypes" class="simple">
       <caption>A list of the RDF-compatible XSD types, with short descriptions</caption>
@@ -1224,7 +1223,7 @@
 
     <p class="note">Semantic extensions of RDF might choose to
       recognize other datatype IRIs
-      and require them to refer to a fixed datatype.
+      and require each of them to refer to a fixed datatype.
       See [[[RDF12-SEMANTICS]]] [[RDF12-SEMANTICS]] for more information on
       semantic extensions.</p>
 
@@ -1311,7 +1310,7 @@
 
 
   <p>Generalized RDF triples, graphs, and datasets differ
-    from normative RDF <a>triples</a>,
+    from standard normative RDF <a>triples</a>,
     <a data-lt="RDF graph">graphs</a>, and
     <a data-lt="RDF dataset">datasets</a> only
     by allowing <a>IRIs</a>,
@@ -1324,8 +1323,8 @@
     aware that these notions are non-standard extensions of
     RDF, and their use may cause interoperability problems.
     There is no requirement for any RDF tool to
-    accept, process, or produce anything beyond standard RDF
-    triples, graphs, and datasets. </p>
+    accept, process, or produce anything beyond standard
+    normative RDF triples, graphs, and datasets. </p>
 
 </section>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -1498,7 +1498,7 @@
         in order to avoid side effects with existing specifications.
       </dd>
 
-      <dt>The <a>lexical-to-value mapping</a></dt>
+      <dt id="JSON-mapping>The <a>lexical-to-value mapping</a></dt>
       <dd>
         maps every element of the lexical space to the result of
         <ol>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1199,7 +1199,7 @@
       MUST refer to the RDF-compatible XSD type named <code>xsd:xxx</code> for
       every XSD type listed in <a href="#xsd-datatypes">section 5.1</a>.</p>
 
-    <p>The following three datatype IRIs are defined in this section:</p>
+    <p>The following three datatype IRIs are defined in Appendix&nbsp;<a href="#section-additional-datatypes" class="sectionRef"></a>:</p>
 
     <ul>
       <li>The IRI <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral</code>
@@ -1237,6 +1237,101 @@
       is suggested in [[SWBP-XSCH-DATATYPES]]. RDF implementations
       are not required to support either of these facilities.</p>
   </section>
+</section>
+
+<section id="section-fragID" class="informative">
+  <h2>Fragment Identifiers</h2>
+
+  <p>RDF uses <a>IRIs</a>, which may include
+    <span id="dfn-fragment-identifiers"><!-- obsolete term--></span>
+    <dfn data-lt="fragment identifier" class="no-export">fragment identifiers</dfn>,
+    as resource identifiers.
+    The semantics of fragment identifiers is
+    <a data-cite="rfc3986#section-3.5">defined in
+    RFC 3986</a> [[RFC3986]]: They identify a secondary resource
+    that is usually a part of, view of, defined in, or described in
+    the primary resource, and the precise semantics depend on the set
+    of representations that might result from a retrieval action
+    on the primary resource.</p>
+
+  <p>This section discusses the handling of fragment identifiers
+    in representations that encode <a>RDF graphs</a>.</p>
+
+  <p>In RDF-bearing representations of a primary resource
+    <code>&lt;foo&gt;</code>,
+    the secondary resource identified by a fragment <code>bar</code>
+    is the <a>resource</a> <a>denoted</a> by the
+    full <a>IRI</a> <code>&lt;foo#bar&gt;</code> in the <a>RDF graph</a>.
+    Since IRIs in RDF graphs can denote anything, this can be
+    something external to the representation, or even external
+    to the web.</p>
+
+  <p>In this way, the RDF-bearing representation acts as an intermediary
+    between the web-accessible primary resource, and some set of possibly
+    non-web or abstract entities that the <a>RDF graph</a> may describe.</p>
+
+  <p>In cases where other specifications constrain the semantics of
+    <a>fragment identifiers</a> in RDF-bearing representations, the encoded
+    <a>RDF graph</a> should use fragment identifiers in a way that is consistent
+    with these constraints. For example, in an HTML+RDFa document [[HTML-RDFA]],
+    the fragment <code>chapter1</code> may identify a document section
+    via the semantics of HTML's <code>@name</code> or <code>@id</code>
+    attributes. The <a>IRI</a> <code>&lt;#chapter1&gt;</code> should
+    then be taken to <a>denote</a> that same section in any RDFa-encoded
+    <a>triples</a> within the same document.
+    Similarly, fragment identifiers should be used consistently in resources
+    with multiple representations that are made available via
+    <a data-cite="webarch/#frag-coneg">content negotiation</a>
+    [[WEBARCH]]. For example, if the fragment <code>chapter1</code> identifies a
+    document section in an HTML representation of the primary resource, then the
+    <a>IRI</a> <code>&lt;#chapter1&gt;</code> should be taken to
+    <a>denote</a> that same section in all RDF-bearing representations of the
+    same primary resource.</p>
+</section>
+
+<section id="section-generalized-rdf" class="informative">
+  <h2>Generalized RDF Triples, Graphs, and Datasets</h2>
+
+  <p>It is sometimes convenient to loosen the requirements
+    on <a>RDF triple</a>s.  For example, the completeness
+    of the RDFS entailment rules is easier to show with a
+    generalization of RDF triples.</p>
+
+  <p>A <dfn class="export">generalized RDF triple</dfn> is a triple having a subject,
+    a predicate, and object, where each can be an <a>IRI</a>, a
+    <a>blank node</a> or a
+    <a>literal</a>. A
+    <dfn class="export">generalized RDF graph</dfn>
+    is a set of generalized RDF triples. A
+    <dfn class="export">generalized RDF dataset</dfn>
+    comprises a distinguished generalized RDF graph, and zero
+    or more pairs each associating an IRI, a blank node or a literal
+    to a generalized RDF graph.</p>
+
+
+  <p>Generalized RDF triples, graphs, and datasets differ
+    from normative RDF <a>triples</a>,
+    <a data-lt="RDF graph">graphs</a>, and
+    <a data-lt="RDF dataset">datasets</a> only
+    by allowing <a>IRIs</a>,
+    <a>blank nodes</a> and
+    <a>literals</a> to appear
+    in any position, i.e., as subject, predicate, object or graph names.</p>
+
+  <p class="note" id="note-generalized-rdf"> Any users of
+    generalized RDF triples, graphs or datasets need to be
+    aware that these notions are non-standard extensions of
+    RDF and their use may cause interoperability problems.
+    There is no requirement on the part of any RDF tool to
+    accept, process, or produce anything beyond standard RDF
+    triples, graphs, and datasets. </p>
+
+</section>
+
+
+<section id="section-additional-datatypes" class="appendix">
+  <h2>Additional Datatypes</h2>
+  <p>This section defines additional <a>datatypes</a> that RDF processors MAY support.</p>
 
   <section id="section-html">
     <h3>The <code>rdf:HTML</code> Datatype</h3>
@@ -1359,96 +1454,9 @@
       in [[?JSON-LD11]].
     </p>
   </section>
-</section>
-
-<section id="section-fragID" class="informative">
-  <h2>Fragment Identifiers</h2>
-
-  <p>RDF uses <a>IRIs</a>, which may include
-    <span id="dfn-fragment-identifiers"><!-- obsolete term--></span>
-    <dfn data-lt="fragment identifier" class="no-export">fragment identifiers</dfn>,
-    as resource identifiers.
-    The semantics of fragment identifiers is
-    <a data-cite="rfc3986#section-3.5">defined in
-    RFC 3986</a> [[RFC3986]]: They identify a secondary resource
-    that is usually a part of, view of, defined in, or described in
-    the primary resource, and the precise semantics depend on the set
-    of representations that might result from a retrieval action
-    on the primary resource.</p>
-
-  <p>This section discusses the handling of fragment identifiers
-    in representations that encode <a>RDF graphs</a>.</p>
-
-  <p>In RDF-bearing representations of a primary resource
-    <code>&lt;foo&gt;</code>,
-    the secondary resource identified by a fragment <code>bar</code>
-    is the <a>resource</a> <a>denoted</a> by the
-    full <a>IRI</a> <code>&lt;foo#bar&gt;</code> in the <a>RDF graph</a>.
-    Since IRIs in RDF graphs can denote anything, this can be
-    something external to the representation, or even external
-    to the web.</p>
-
-  <p>In this way, the RDF-bearing representation acts as an intermediary
-    between the web-accessible primary resource, and some set of possibly
-    non-web or abstract entities that the <a>RDF graph</a> may describe.</p>
-
-  <p>In cases where other specifications constrain the semantics of
-    <a>fragment identifiers</a> in RDF-bearing representations, the encoded
-    <a>RDF graph</a> should use fragment identifiers in a way that is consistent
-    with these constraints. For example, in an HTML+RDFa document [[HTML-RDFA]],
-    the fragment <code>chapter1</code> may identify a document section
-    via the semantics of HTML's <code>@name</code> or <code>@id</code>
-    attributes. The <a>IRI</a> <code>&lt;#chapter1&gt;</code> should
-    then be taken to <a>denote</a> that same section in any RDFa-encoded
-    <a>triples</a> within the same document.
-    Similarly, fragment identifiers should be used consistently in resources
-    with multiple representations that are made available via
-    <a data-cite="webarch/#frag-coneg">content negotiation</a>
-    [[WEBARCH]]. For example, if the fragment <code>chapter1</code> identifies a
-    document section in an HTML representation of the primary resource, then the
-    <a>IRI</a> <code>&lt;#chapter1&gt;</code> should be taken to
-    <a>denote</a> that same section in all RDF-bearing representations of the
-    same primary resource.</p>
-</section>
-
-<section id="section-generalized-rdf" class="informative">
-  <h2>Generalized RDF Triples, Graphs, and Datasets</h2>
-
-  <p>It is sometimes convenient to loosen the requirements
-    on <a>RDF triple</a>s.  For example, the completeness
-    of the RDFS entailment rules is easier to show with a
-    generalization of RDF triples.</p>
-
-  <p>A <dfn class="export">generalized RDF triple</dfn> is a triple having a subject,
-    a predicate, and object, where each can be an <a>IRI</a>, a
-    <a>blank node</a> or a
-    <a>literal</a>. A
-    <dfn class="export">generalized RDF graph</dfn>
-    is a set of generalized RDF triples. A
-    <dfn class="export">generalized RDF dataset</dfn>
-    comprises a distinguished generalized RDF graph, and zero
-    or more pairs each associating an IRI, a blank node or a literal
-    to a generalized RDF graph.</p>
-
-
-  <p>Generalized RDF triples, graphs, and datasets differ
-    from normative RDF <a>triples</a>,
-    <a data-lt="RDF graph">graphs</a>, and
-    <a data-lt="RDF dataset">datasets</a> only
-    by allowing <a>IRIs</a>,
-    <a>blank nodes</a> and
-    <a>literals</a> to appear
-    in any position, i.e., as subject, predicate, object or graph names.</p>
-
-  <p class="note" id="note-generalized-rdf"> Any users of
-    generalized RDF triples, graphs or datasets need to be
-    aware that these notions are non-standard extensions of
-    RDF and their use may cause interoperability problems.
-    There is no requirement on the part of any RDF tool to
-    accept, process, or produce anything beyond standard RDF
-    triples, graphs, and datasets. </p>
 
 </section>
+
 
 <section id="privacy" class="appendix informative">
   <h2>Privacy Considerations</h2>
@@ -1681,6 +1689,9 @@
       avoiding the incorrect use of "absolute IRI".</li>
     <li>Changed reference from DOM4, which was not a recommendation at the time, to [[DOM]],
       making the <a>rdf:HTML</a> and <a>rdf:XMLLiteral</a> datatypes normative.</li>
+    <li>Added <a href="#section-additional-datatypes" class="sectionRef"></a>
+      and moved the sections about the <a>rdf:HTML</a> and <a>rdf:XMLLiteral</a>
+      datatypes to this appendix.</li>
     <li>Clarify Unicode terminology,
       using <a data-lt="code point" class="lint-ignore">Unicode code points</a>,
       and restriction to the XML <a data-cite="XML11#charsets">Char</a> production.

--- a/spec/index.html
+++ b/spec/index.html
@@ -1460,52 +1460,49 @@
       <dd>is <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON</code>.</dd>
 
       <dt id="JSON-lexical-space">The <a>lexical space</a></dt>
-      <dd>is the set of all <a>strings</a> that conform to the
+      <dd>is the set of all <a data-lt="string">RDF strings</a> that conform to the
         <a data-cite="RFC4627#section-2">JSON Grammar</a> as described in
         <a data-cite="RFC8259#section-2">Section&nbsp;2 JSON Grammar</a> of
         [[RFC8259]].</dd>
 
       <dt id="JSON-value-space">The <a>value space</a></dt>
       <dd>
-        is a single <a data-cite="RFC4627#section-3">JSON value</a> in the form of an <a data-lt="list">array</a>,
-        <a>map</a>,
-        <a>string</a>,
+        is a single <a data-cite="RFC4627#section-2.1">JSON value</a> in the form of an <a data-cite="INFRA#list">array</a>,
+        <a data-cite="INFRA#ordered-map">map</a>,
+        <a data-cite="INFRA#string">string</a>,
         <a data-cite="ECMASCRIPT#sec-terms-and-definitions-number-value">number</a>,
-        <a>boolean</a>, or
+        <a data-cite="INFRA#boolean">boolean</a>, or
         <a data-cite="INFRA#nulls">null</a>.
         <ul>
-          <li><a data-lt="list">Array</a> <a data-cite="INFRA#list-item">entries</a> may be
-            <a>map</a>,
-            <a>string</a>,
-            <a data-cite="ECMASCRIPT#sec-terms-and-definitions-number-value">number</a>,
-            <a>boolean</a>, or
-            <a data-cite="INFRA#nulls">null</a>.</li>
-          <li><a>Map</a> <a data-cite="INFRA#map-key">keys</a> are <a>strings</a> with
-            <a data-cite="INFRA#map-value">values</a> may be any of the above
-            <a data-cite="RFC4627#section-3">JSON values</a>.</li>
+          <li><a data-cite="INFRA#list">Array</a> <a data-cite="INFRA#list-item">entries</a> may be
+            any of the above <a data-cite="RFC4627#section-2.1">JSON values</a>.</li>
+          <li><a data-cite="INFRA#ordered-map">Map</a> <a data-cite="INFRA#map-key">keys</a> are <a data-cite="INFRA#string">strings</a> with
+            <a data-cite="INFRA#map-value">values</a>, which may be any of the above
+            <a data-cite="RFC4627#section-2.1">JSON values</a>.</li>
         </ul>
 
-        Two <a data-cite="RFC4627#section-3">JSON values</a> are considered equal
-        if they are the same if they are the same <a>string</a>,
+        Two <a data-cite="RFC4627#section-2.1">JSON values</a> are considered equal
+        if they are the same if they are the same <a data-cite="INFRA#string">string</a>,
         <a data-cite="ECMASCRIPT#sec-terms-and-definitions-number-value">number</a>,
-        <a>boolean</a>, or
+        <a data-cite="INFRA#boolean">boolean</a>, or
         <a data-cite="INFRA#nulls">null</a>,
-        if they are both an <a data-lt="list">array</a> with equal <a data-cite="INFRA#list-item">entries</a>, or
-        if they are both a <a>map</a> with equal <a data-cite="INFRA#map-entry">map entries</a>.
+        if they are both <a data-cite="INFRA#list">arrays</a> with <a data-cite="INFRA#list-item">entries</a>
+        which are pairwise equal,
+        or if they are both a <a data-cite="INFRA#ordered-map">map</a> with equal <a data-cite="INFRA#map-entry">map entries</a>.
       </dd>
 
       <dt id="JSON-mapping">The <a>lexical-to-value mapping</a></dt>
       <dd>
         maps every element of the lexical space to the result of parsing it into a
-        <a data-cite="RFC4627#section-3">JSON value</a>
+        <a data-cite="RFC4627#section-2.1">JSON value</a>
         consistent with the [[ECMASCRIPT]] representation created by using the <code>JSON.parse</code>
         function as defined in <a data-cite="ECMASCRIPT#sec-json-object">Section&nbsp;24.5 The JSON Object</a>
         of [[ECMASCRIPT]].
       </dd>
 
       <dt id="JSON-canonical">The canonical mapping</dt>
-      <dd>maps a <a data-cite="RFC4627#section-3">JSON value</a>
-        to a <a>string</a> conforming to the <a data-cite="RFC4627#section-2">JSON Grammar</a>
+      <dd>maps a <a data-cite="RFC4627#section-2.1">JSON value</a>
+        to an <a data-lt="string">RDF string</a> conforming to the <a data-cite="RFC4627#section-2">JSON Grammar</a>
         using the mechanism described in [[[RFC8785]] [[RFC8785]].
       </dd>
     </dl>


### PR DESCRIPTION
[As agreed during the FSF meeting at TPAC](https://www.w3.org/2023/09/12-rdf-star-minutes.html#t07), this PR
1. adds a new appendix,
2. moves the sections that define the `rdf:HTML` and `rdf:XMLLiteral` datatypes into that appendix, and
3. copies the definition of the `rdf:JSON` datatype from [Section 10.2 of [JSON_LD11]](https://www.w3.org/TR/json-ld11/#the-rdf-json-datatype) into this new appendix as well.

Regarding the latter, I have indeed just copied the definition of the `rdf:JSON` datatype. When doing so, there were two things that I was wondering:
1. The sentence that defines the lexical space contains two different links for "JSON Grammar". The first one points to Sec.2 of RFC4627, and the second one points to Sec.2 of RFC8259. I was wondering, why these two different links?
4. There is an issue box about the JSON Canonicalization Scheme (JCS) which I also copied (note, in this copy I had to make a slight change because JSON-LD11 explicitly defines [JSON Literal](https://www.w3.org/TR/json-ld11/#dfn-json-literal), which we don't have in RDF Concepts). However, I have to admit that I do not fully understand the last sentence in this issue box ("Users are cautioned from depending on the [JSON literal](https://www.w3.org/TR/json-ld11/#dfn-json-literal) lexical representation as an [RDF literal](https://www.w3.org/TR/rdf11-concepts/#dfn-literal), as the specifics of serialization may change in a future revision of this document."). In particular, I wonder:
    1. What "serialization" does the last part of his sentence refer to?
    2. What is meant by "this document"? (the JSON-LD11 spec or the JCS spec?)
    5. Also, is this whole comment something specific to JSON-LD?

([GitHack preview](https://raw.githack.com/w3c/rdf-concepts/Issue14/spec/index.html))


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/62.html" title="Last updated on Sep 21, 2023, 6:38 PM UTC (40c1c01)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/62/fe28411...40c1c01.html" title="Last updated on Sep 21, 2023, 6:38 PM UTC (40c1c01)">Diff</a>