### PR TITLE
[WIP] Change quoted triples to quoted graphs / graph terms

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -66,7 +66,7 @@
       are comprised of a default graph and zero or more named graphs.</li>
   </ul>
 
-  <p>RDF 1.2 introduces <a>quoted triples</a> as another kind of <a>RDF term</a>
+  <p>RDF 1.2 introduces <a>quoted graphs</a> as another kind of <a>RDF term</a>
     which can be used as the <a>subject</a> or <a>object</a> of another <a>triple</a>.</p>
 
   <p>RDF 1.2 Concepts introduces key concepts and terminology for RDF 1.2, discusses
@@ -126,7 +126,7 @@
 
     <p>There can be four kinds of <a>nodes</a> in an
       <a>RDF graph</a>: <a>IRIs</a>, <a>literals</a>,
-      <a>blank nodes</a>, and <a>quoted triples</a>.</p>
+      <a>blank nodes</a>, and <a>quoted graphs</a>.</p>
 
   </section>
 
@@ -167,57 +167,71 @@
       exists, without explicitly naming it.</p>
   </section>
 
-  <section id="section-quoted-triples">
-    <h3>Quoted Triples</h3>
+  <section id="section-quoted-graphs">
+    <h3>Quoted Graphs</h3>
 
-    <p>A <a>quoted triple</a> is an <a>RDF term</a> with the components of
-      an <a>RDF triple</a>, which can be used as the <a>subject</a> or <a>object</a>
+    <p>A <a>quoted graph</a> is an <a>RDF term</a> with the components of
+      an <a>RDF graph</a>, which can be used as the <a>subject</a> or <a>object</a>
       of another triple.</p>
 
-    <p>A <a>quoted triple</a> is not necessarily asserted, allowing
+    <p>A <a>quoted graph</a> is not necessarily asserted, allowing
       statements to be made about other statements that may not be
-      asserted within an <a>RDF graph</a>.
+      asserted within another <a>RDF graph</a>.
       This allows statements to be made about relationships that may be contradictory.
-      For a <a>quoted triple</a> to be asserted,
-      it must also appear in a graph as an <a>asserted triple</a>.</p>
+      For a <a>quoted graph</a> to be asserted,
+      the triples it contains must also appear in a graph which is not <a>quoted</a>.</p>
 
-    <p>The following diagram represents a statement with an unasserted <a>quoted triple</a>
+    <p>The following diagram represents a statement with an unasserted <a>quoted graph</a>
       as the subject.</p>
 
-    <figure id="fig-quoted-triple">
+    <figure id="fig-quoted-graph">
       <a href="quoted-triple.svg">
         <!-- Source for this file is at https://docs.google.com/drawings/d/1I_QxbUgnQXumXzb8c0WNJHIQ-mtRs2S80dDG6i9aOD8 -->
         <img src="quoted-triple.svg"
-             alt="An RDF graph containing a triple that references an unasserted quoted triple (with grey background) as the subject"
+             alt="An RDF graph containing a triple that references an unasserted quoted graph (with grey background) as the subject"
              style="width:70%"
-             aria-describedby="fig-quoted-triple-alt"/>
+             aria-describedby="fig-quoted-graph-alt"/>
       </a>
-      <figcaption id="fig-quoted-triple-alt">
-        An RDF graph containing a triple that references an unasserted quoted triple (with grey background) as the subject.
+      <figcaption id="fig-quoted-graph-alt">
+        An RDF graph containing a triple that references an unasserted quoted graph (with grey background) as the subject.
       </figcaption>
     </figure>
 
-    <p>A variation on the graph shown in <a href="#fig-quoted-triple"></a> can be described
-      where the <a>quoted triple</a> is also <a data-lt="asserted triple">asserted</a>.</p>
+    <p>A variation on the graph shown in <a href="#fig-quoted-graph"></a> can be described
+      where the triples in the <a>quoted graph</a> are also in the <a>default graph</a>.</p>
 
-    <figure id="fig-quoted-asserted-triple">
+    <figure id="fig-quoted-asserted-graph">
       <a href="quoted-asserted-triple.svg">
         <!-- Source for this file is at https://docs.google.com/drawings/d/1aoUEsb07P-nu5rvPRob7O07CRKgnf7tBw2CmRJNuaQ0 -->
         <img src="quoted-asserted-triple.svg"
              alt="An RDF graph containing two triples where one of them contains the other as the subject; hence, that other triple is both quoted and asserted"
              style="width:70%"
-             aria-describedby="fig-quoted-asserted-triple-alt"/>
+             aria-describedby="fig-quoted-asserted-graph-alt"/>
       </a>
-      <figcaption id="fig-quoted-asserted-triple-alt">
+      <figcaption id="fig-quoted-asserted-graph-alt">
         An RDF graph containing two triples where one of them contains the other as the subject;
         hence, that other triple is both quoted and asserted.
       </figcaption>
     </figure>
 
-    <p>Note that a <a>quoted triple</a> may also have a quoted triple as its subject or object.</p>
+    <p>A quoted graph may contain triples which also have quoted graphs as subjects or objects.</p>
 
-    <p class="issue" data-number="34">
-      This issue considers the potential for additional terminology related to <a>quoted triples</a>.
+    <p class="note">
+      The concept of a quoted graph is similar to that of a named graph,
+      however a quoted graph does not have a name, and is intended to be used as the
+      subject or object of other triples.
+    </p>
+
+    <p class="issue">
+      An alternative interpretation is that quoted graphs can have a blank node name,
+      which can also be used as the subject or object of other triples.
+      These blank node named graphs (or <em>blank graphs</em> may have semantics distinct
+      from graphs named using IRIs or using blank nodes which are not also
+      the subject or object of another triple).
+    </p>
+
+    <p class="issue" data-number="46">
+      This issue considers using <a>quoted graphs</a> as an alternative to quoted triples.
     </p>
   </section>
 
@@ -482,23 +496,6 @@
     but can conform to such other specifications that normatively
     reference terms defined here.</p>
 
-  <p>This specification establishes two conformance levels:</p>
-
-  <ul>
-    <li><dfn class="no-export lint-ignore">Full</dfn> conformance
-      supports <a data-lt="RDF graph">graphs</a> and <a data-lt="RDF dataset">datasets</a>
-      containing <a>quoted triples</a>.
-      Concrete syntaxes in which such graphs and datasets can be expressed include
-      [[RDF12-N-TRIPLES]], [[RDF12-N-QUADS]], [[RDF12-TURTLE]], and [[RDF12-TRIG]].</li>
-    <li><dfn class="no-export lint-ignore">Classic</dfn> conformance
-      only supports <a data-lt="RDF graph">graphs</a> or <a data-lt="RDF dataset">datasets</a>,
-      that do not contain <a>quoted triples</a>.</li>
-  </ul>
-  <p class="ednote">The conformance levels described above are tentative,
-    and still the subject of group discussion. An alternative to conformance
-    levels, "profiles", may be adopted instead, abandoned, or described in 
-    another specification.</p>
-
   <section id="rdf-strings">
     <h2>Strings in RDF</h2>
 
@@ -559,27 +556,28 @@
       |p| is called the <dfn>predicate</dfn> of the triple, and
       |o| is called the <dfn>object</dfn> of the triple.</p>
 
-    <p>A <dfn data-local-lt="quoted">quoted triple</dfn> is an <a>RDF triple</a> that is
-      used as the <a>subject</a> or <a>object</a> of another triple.</p>
+    <p>A <dfn data-local-lt="quoted">quoted graph</dfn> is an <a>RDF graph</a> that is
+      used as the <a>subject</a> or <a>object</a> of triple.</p>
 
     <p class="note">By the given definitions,
       the <a>subject</a> of an <a>RDF triple</a> may be either an <a>IRI</a>,
-      a <a>blank node</a>, or a <a>quoted triple</a>;
+      a <a>blank node</a>, or a <a>quoted graph</a>;
       the <a>predicate</a> of an <a>RDF triple</a> may only be an <a>IRI</a>;
       the <a>object</a> of an <a>RDF triple</a> may be either an <a>IRI</a>,
-      a <a>blank node</a>, a <a>literal</a> or a <a>quoted triple</a>.</p>
+      a <a>blank node</a>, a <a>literal</a> or a <a>quoted graph</a>.</p>
 
-    <p class="note">The definition of <a>quoted triple</a> is recursive.
-      That is, a <a>quoted triple</a> can itself have a
-      <a>subject</a> or <a>object</a> component which is another <a>quoted triple</a>.
-      However, by this definition, cycles of <a>quoted triples</a> cannot be created.</p>
+    <p class="note">The definition of <a>quoted graph</a> is recursive.
+      That is, a <a>quoted graph</a> can itself have a
+      triples where the <a>subject</a> or <a>object</a> components
+      are <a>quoted graphs</a>.
+      However, by this definition, cycles of <a>quoted graphs</a> cannot be created.</p>
 
     <p><a>IRIs</a>, <a>literals</a>,
-      <a>blank nodes</a>, and <a>quoted triples</a> are collectively known as
+      <a>blank nodes</a>, and <a>quoted graphs</a> are collectively known as
       <span id="dfn-rdf-terms"><!-- obsolete term--></span><dfn data-lt="rdf term">RDF terms</dfn>.</p>
 
     <p><a>IRIs</a>, <a>literals</a>,
-      <a>blank nodes</a>, and <a>quoted triples</a> are distinct and distinguishable.
+      <a>blank nodes</a>, and <a>quoted graphs</a> are distinct and distinguishable.
       For example, <code>http://example.org/</code> as a string literal
       is equal to neither <code>http://example.org/</code> as an IRI,
       nor a blank node with the <a>blank node identifier</a>
@@ -589,13 +587,6 @@
       is the set of <a>subjects</a> and <a>objects</a> of <a>triples</a> in the graph.
       It is possible for a predicate IRI to also occur as a node in
       the same graph.</p>
-
-    <p>An <dfn data-local-lt="asserted">asserted triple</dfn>
-      is an <a>RDF triple</a> that is an element of an <a>RDF graph</a>.</p>
-
-    <p class="note">In an <a>RDF graph</a>,
-      a <a>triple</a> may occur as either a <a>quoted triple</a>, an 
-      <a>asserted triple</a>, or both.</p>
   </section>
 
   <section id="section-IRIs">
@@ -1742,8 +1733,8 @@
   <ul>
     <li>Added <a href="#section-dataset-quad" class="sectionRef"></a>
       for informative definition of a <a>quad</a>.</li>
-    <li>Added <a href="#section-quoted-triples" class="sectionRef"></a>
-      and definitions for <a>quoted triple</a> and <a>asserted triple</a>.</li>
+    <li>Added <a href="#section-quoted-graphs" class="sectionRef"></a>
+      and definitions for <a>quoted graph</a>.</li>
     <li>Improved the use of IRI terminology,
       and added <a href="#iri-abnf" class="sectionRef"></a>.
       This improves the language using <a>relative IRI references</a>

--- a/spec/index.html
+++ b/spec/index.html
@@ -541,11 +541,11 @@
       </li>
 
       <li>
-        If |t| and <var>t'</var> are <a>RDF triples</a>,
+        If <var>G</var> and <var>G'</var> are <a>RDF graphs</a>,
         |s| is an <a>IRI</a> or a <a>blank node</a>,
         |p| is an <a>IRI</a>, and
         |o| is an <a>IRI</a>, a <a>blank node</a>, or a <a>literal</a>,
-        then (|t|, |p|, |o|), (|s|, |p|, |t|), and (|t|, |p|, <var>t'</var>) are RDF triples.
+        then (<var>G</var>, |p|, |o|), (|s|, |p|, <var>G</var>), and (<var>G</var>, |p|, <var>G'</var>) are RDF triples.
       </li>
     </ul>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -66,7 +66,7 @@
       are comprised of a default graph and zero or more named graphs.</li>
   </ul>
 
-  <p>RDF 1.2 introduces <a>quoted graphs</a> as another kind of <a>RDF term</a>
+  <p>RDF 1.2 introduces <a>graph terms</a> as another kind of <a>RDF term</a>
     which can be used as the <a>subject</a> or <a>object</a> of another <a>triple</a>.</p>
 
   <p>RDF 1.2 Concepts introduces key concepts and terminology for RDF 1.2, discusses
@@ -126,7 +126,7 @@
 
     <p>There can be four kinds of <a>nodes</a> in an
       <a>RDF graph</a>: <a>IRIs</a>, <a>literals</a>,
-      <a>blank nodes</a>, and <a>quoted graphs</a>.</p>
+      <a>blank nodes</a>, and <a>graph terms</a>.</p>
 
   </section>
 
@@ -167,71 +167,71 @@
       exists, without explicitly naming it.</p>
   </section>
 
-  <section id="section-quoted-graphs">
-    <h3>Quoted Graphs</h3>
+  <section id="section-graph-terms">
+    <h3>Graph Terms</h3>
 
-    <p>A <a>quoted graph</a> is an <a>RDF term</a> with the components of
+    <p>A <a>graph term</a> is an <a>RDF term</a> with the components of
       an <a>RDF graph</a>, which can be used as the <a>subject</a> or <a>object</a>
       of another triple.</p>
 
-    <p>A <a>quoted graph</a> is not necessarily asserted, allowing
+    <p>A <a>graph term</a> is not necessarily asserted, allowing
       statements to be made about other statements that may not be
       asserted within another <a>RDF graph</a>.
       This allows statements to be made about relationships that may be contradictory.
-      For a <a>quoted graph</a> to be asserted,
-      the triples it contains must also appear in a graph which is not <a>quoted</a>.</p>
+      For a <a>graph term</a> to be asserted,
+      the triples it contains must also appear in a graph which is not a <a>graph term</a>.</p>
 
-    <p>The following diagram represents a statement with an unasserted <a>quoted graph</a>
+    <p>The following diagram represents a statement with an unasserted <a>graph term</a>
       as the subject.</p>
 
-    <figure id="fig-quoted-graph">
+    <figure id="fig-graph-term">
       <a href="quoted-triple.svg">
         <!-- Source for this file is at https://docs.google.com/drawings/d/1I_QxbUgnQXumXzb8c0WNJHIQ-mtRs2S80dDG6i9aOD8 -->
         <img src="quoted-triple.svg"
-             alt="An RDF graph containing a triple that references an unasserted quoted graph (with grey background) as the subject"
+             alt="An RDF graph containing a triple that references an unasserted graph term (with grey background) as the subject"
              style="width:70%"
-             aria-describedby="fig-quoted-graph-alt"/>
+             aria-describedby="fig-graph-term-alt"/>
       </a>
-      <figcaption id="fig-quoted-graph-alt">
-        An RDF graph containing a triple that references an unasserted quoted graph (with grey background) as the subject.
+      <figcaption id="fig-graph-term-alt">
+        An RDF graph containing a triple that references an unasserted graph term (with grey background) as the subject.
       </figcaption>
     </figure>
 
-    <p>A variation on the graph shown in <a href="#fig-quoted-graph"></a> can be described
-      where the triples in the <a>quoted graph</a> are also in the <a>default graph</a>.</p>
+    <p>A variation on the graph shown in <a href="#fig-graph-term"></a> can be described
+      where the triples in the <a>graph term</a> are also in the <a>default graph</a>.</p>
 
-    <figure id="fig-quoted-asserted-graph">
+    <figure id="fig-asserted-graph-term">
       <a href="quoted-asserted-triple.svg">
         <!-- Source for this file is at https://docs.google.com/drawings/d/1aoUEsb07P-nu5rvPRob7O07CRKgnf7tBw2CmRJNuaQ0 -->
         <img src="quoted-asserted-triple.svg"
-             alt="An RDF graph containing two triples where one of them contains the other as the subject; hence, that other triple is both quoted and asserted"
+             alt="An RDF graph containing two triples where one of them contains the other as the subject; hence, that other triple is both asserted and the content of a graph term"
              style="width:70%"
-             aria-describedby="fig-quoted-asserted-graph-alt"/>
+             aria-describedby="fig-asserted-graph-term-alt"/>
       </a>
-      <figcaption id="fig-quoted-asserted-graph-alt">
+      <figcaption id="fig-asserted-graph-term-alt">
         An RDF graph containing two triples where one of them contains the other as the subject;
-        hence, that other triple is both quoted and asserted.
+        hence, that other triple is both asserted and the content of a graph term.
       </figcaption>
     </figure>
 
-    <p>A quoted graph may contain triples which also have quoted graphs as subjects or objects.</p>
+    <p>A graph term may contain triples which also have graph terms as subjects or objects.</p>
 
     <p class="note">
-      The concept of a quoted graph is similar to that of a named graph,
-      however a quoted graph does not have a name, and is intended to be used as the
-      subject or object of other triples.
+      The concept of a graph term is similar to that of a named graph,
+      however a graph term does not have a name, and is intended to be used as the
+      subject or object of RDF triples.
     </p>
 
     <p class="issue">
-      An alternative interpretation is that quoted graphs can have a blank node name,
+      An alternative interpretation is that graph terms can have a blank node name,
       which can also be used as the subject or object of other triples.
-      These blank node named graphs (or <em>blank graphs</em> may have semantics distinct
+      These blank node named graphs (or <em>blank graphs</em>) may have semantics distinct
       from graphs named using IRIs or using blank nodes which are not also
-      the subject or object of another triple).
+      the subject or object of another triple.
     </p>
 
     <p class="issue" data-number="46">
-      This issue considers using <a>quoted graphs</a> as an alternative to quoted triples.
+      This issue considers using <a>graph terms</a> as an alternative to quoted triples.
     </p>
   </section>
 
@@ -556,28 +556,28 @@
       |p| is called the <dfn>predicate</dfn> of the triple, and
       |o| is called the <dfn>object</dfn> of the triple.</p>
 
-    <p>A <dfn data-local-lt="quoted">quoted graph</dfn> is an <a>RDF graph</a> that is
-      used as the <a>subject</a> or <a>object</a> of triple.</p>
+    <p>A <dfn>graph term</dfn> is an <a>RDF graph</a> that is
+      used as the <a>subject</a> or <a>object</a> of a <a>triple</a>.</p>
 
     <p class="note">By the given definitions,
       the <a>subject</a> of an <a>RDF triple</a> may be either an <a>IRI</a>,
-      a <a>blank node</a>, or a <a>quoted graph</a>;
+      a <a>blank node</a>, or a <a>graph term</a>;
       the <a>predicate</a> of an <a>RDF triple</a> may only be an <a>IRI</a>;
       the <a>object</a> of an <a>RDF triple</a> may be either an <a>IRI</a>,
-      a <a>blank node</a>, a <a>literal</a> or a <a>quoted graph</a>.</p>
+      a <a>blank node</a>, a <a>literal</a> or a <a>graph term</a>.</p>
 
-    <p class="note">The definition of <a>quoted graph</a> is recursive.
-      That is, a <a>quoted graph</a> can itself have a
+    <p class="note">The definition of <a>graph term</a> is recursive.
+      That is, a <a>graph term</a> can itself contain
       triples where the <a>subject</a> or <a>object</a> components
-      are <a>quoted graphs</a>.
-      However, by this definition, cycles of <a>quoted graphs</a> cannot be created.</p>
+      are <a>graph terms</a>.
+      However, by this definition, cycles of <a>graph terms</a> cannot be created.</p>
 
     <p><a>IRIs</a>, <a>literals</a>,
-      <a>blank nodes</a>, and <a>quoted graphs</a> are collectively known as
+      <a>blank nodes</a>, and <a>graph terms</a> are collectively known as
       <span id="dfn-rdf-terms"><!-- obsolete term--></span><dfn data-lt="rdf term">RDF terms</dfn>.</p>
 
     <p><a>IRIs</a>, <a>literals</a>,
-      <a>blank nodes</a>, and <a>quoted graphs</a> are distinct and distinguishable.
+      <a>blank nodes</a>, and <a>graph terms</a> are distinct and distinguishable.
       For example, <code>http://example.org/</code> as a string literal
       is equal to neither <code>http://example.org/</code> as an IRI,
       nor a blank node with the <a>blank node identifier</a>
@@ -1733,8 +1733,8 @@
   <ul>
     <li>Added <a href="#section-dataset-quad" class="sectionRef"></a>
       for informative definition of a <a>quad</a>.</li>
-    <li>Added <a href="#section-quoted-graphs" class="sectionRef"></a>
-      and definitions for <a>quoted graph</a>.</li>
+    <li>Added <a href="#section-graph-terms" class="sectionRef"></a>
+      and definitions for <a>graph terms</a>.</li>
     <li>Improved the use of IRI terminology,
       and added <a href="#iri-abnf" class="sectionRef"></a>.
       This improves the language using <a>relative IRI references</a>

--- a/spec/index.html
+++ b/spec/index.html
@@ -170,16 +170,16 @@
   <section id="section-graph-terms">
     <h3>Graph Terms</h3>
 
-    <p>A <a>graph term</a> is an <a>RDF term</a> with the components of
-      an <a>RDF graph</a>, which can be used as the <a>subject</a> or <a>object</a>
-      of another triple.</p>
+    <p>A <a>graph term</a> is an <a>RDF graph</a>
+      used as the <a>subject</a> or <a>object</a>
+      of a triple.</p>
 
-    <p>A <a>graph term</a> is not necessarily asserted, allowing
+    <p>The triples in a <a>graph term</a> are not necessarily asserted, allowing
       statements to be made about other statements that may not be
       asserted within another <a>RDF graph</a>.
       This allows statements to be made about relationships that may be contradictory.
-      For a <a>graph term</a> to be asserted,
-      the triples it contains must also appear in a graph which is not a <a>graph term</a>.</p>
+      For the triples in a <a>graph term</a> to be asserted,
+      they must also appear in a graph which is not a <a>graph term</a>.</p>
 
     <p>The following diagram represents a statement with an unasserted <a>graph term</a>
       as the subject.</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -568,8 +568,8 @@
 
     <p class="note">The definition of <a>graph term</a> is recursive.
       That is, a <a>graph term</a> can itself contain
-      triples where the <a>subject</a> or <a>object</a> components
-      are <a>graph terms</a>.
+      triples where either or both the <a>subject</a> and/or <a>object</a> component
+      is a <a>graph term</a>.
       However, by this definition, cycles of <a>graph terms</a> cannot be created.</p>
 
     <p><a>IRIs</a>, <a>literals</a>,

--- a/spec/index.html
+++ b/spec/index.html
@@ -181,24 +181,24 @@
       For the triples in a <a>graph term</a> to be asserted,
       they must also appear in a graph which is not a <a>graph term</a>.</p>
 
-    <p>The following diagram represents a statement with an unasserted <a>graph term</a>
+    <p>The following diagram represents a statement with a <a>graph term</a> containing unasserted triples
       as the subject.</p>
 
     <figure id="fig-graph-term">
       <a href="quoted-triple.svg">
         <!-- Source for this file is at https://docs.google.com/drawings/d/1I_QxbUgnQXumXzb8c0WNJHIQ-mtRs2S80dDG6i9aOD8 -->
         <img src="quoted-triple.svg"
-             alt="An RDF graph containing a triple that references an unasserted graph term (with grey background) as the subject"
+             alt="An RDF graph containing a triple that references a graph term containing unasserted triples (with grey background) as the subject"
              style="width:70%"
              aria-describedby="fig-graph-term-alt"/>
       </a>
       <figcaption id="fig-graph-term-alt">
-        An RDF graph containing a triple that references an unasserted graph term (with grey background) as the subject.
+        An RDF graph containing a triple that references that references a graph term containing unasserted triples (with grey background) as the subject.
       </figcaption>
     </figure>
 
     <p>A variation on the graph shown in <a href="#fig-graph-term"></a> can be described
-      where the triples in the <a>graph term</a> are also in the <a>default graph</a>.</p>
+      where the triples in the <a>graph term</a> (where they are unasserted) are also in the <a>default graph</a> (where they are asserted).</p>
 
     <figure id="fig-asserted-graph-term">
       <a href="quoted-asserted-triple.svg">
@@ -210,7 +210,7 @@
       </a>
       <figcaption id="fig-asserted-graph-term-alt">
         An RDF graph containing two triples where one of them contains the other as the subject;
-        hence, that other triple is both asserted and the content of a graph term.
+        hence, the second triple is both asserted _and_ contained within a graph term.
       </figcaption>
     </figure>
 
@@ -218,7 +218,7 @@
 
     <p class="note">
       The concept of a graph term is similar to that of a named graph,
-      however a graph term does not have a name, and is intended to be used as the
+      however a graph term does not have a name, and is intended to be used only as the
       subject or object of RDF triples.
     </p>
 
@@ -564,13 +564,15 @@
       a <a>blank node</a>, or a <a>graph term</a>;
       the <a>predicate</a> of an <a>RDF triple</a> may only be an <a>IRI</a>;
       the <a>object</a> of an <a>RDF triple</a> may be either an <a>IRI</a>,
-      a <a>blank node</a>, a <a>literal</a> or a <a>graph term</a>.</p>
+      a <a>blank node</a>, a <a>literal</a>, or a <a>graph term</a>.</p>
 
     <p class="note">The definition of <a>graph term</a> is recursive.
       That is, a <a>graph term</a> can itself contain
       triples where either or both the <a>subject</a> and/or <a>object</a> component
       is a <a>graph term</a>.
-      However, by this definition, cycles of <a>graph terms</a> cannot be created.</p>
+      However, by this definition, cycles of <a>graph terms</a> cannot be created;
+      that is, a <a>graph term</a> cannot contain an identical <a>graph term</a> — 
+      a copy of itself — at any depth.</p>
 
     <p><a>IRIs</a>, <a>literals</a>,
       <a>blank nodes</a>, and <a>graph terms</a> are collectively known as


### PR DESCRIPTION
This draft PR is submitted for discussion purposes.

This makes some minimal changes to replace "quoted triple" with "quoted graph". The notion of "asserted triple" is changed to that of a triples contained in graphs which are not quoted.

In this formulation, quoted graphs are terms which suggest graphs which are not named. This opens up more issues about if such graphs can be considered to be named by a blank node, and if the triples it contains must be in the default graph to be considered to be asserted, or any other named graph.

But, mechanically, changing "quoted triple" to "quoted graph" does not substantially change concepts.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/67.html" title="Last updated on Oct 19, 2023, 8:38 PM UTC (e4963fc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/67/727d362...e4963fc.html" title="Last updated on Oct 19, 2023, 8:38 PM UTC (e4963fc)">Diff</a>