### PR TITLE
Case normalization of language tags.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -719,7 +719,7 @@
         language tag MUST be well-formed according to
         <a data-cite="bcp47#section-2.2.9">section 2.2.9</a>
         of [[!BCP47]],
-        and MUST be case normalized consistently (e.g., to lower case)..</li>
+        and MUST be case normalized consistently (e.g., to lower case).</li>
       <li>if and only if the <a>datatype IRI</a> is
         <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#dirLangString</code>,
         a non-empty <a>language tag</a>
@@ -732,7 +732,7 @@
       is present and the fourth element is not present.
       Lexical representations of language tags
       MUST be case normalized
-      and MAY be converted to lower case.
+      and MAY (preferably) be converted to lower case.
       The value of language tags is always treated as being in lower case.</p>
 
     <p>A literal is a <dfn id="dfn-dir-lang-string">directional language-tagged string</dfn>
@@ -1815,7 +1815,7 @@
     <li>Minor edit
       to improve the example about distinguishing literals, IRIs, and blank nodes
       in <a href="#section-triples" class="sectionRef"></a>.</li>
-    <li>Language tags were previously allowed to be normalized to lower case,
+    <li>Implementations were previously allowed to normalize language tags to lower case,
       which made it ambiguous if two literals with language tags different only by case represented the same literal,
       or distinct literals.
       RDF 1.2 requires that language tags be case normalized,

--- a/spec/index.html
+++ b/spec/index.html
@@ -731,9 +731,9 @@
 
     <p>A literal is a <dfn>language-tagged string</dfn> if the third element
       is present and the fourth element is not present.
-      Lexical representations of language tags
-      MUST be case normalized
-      and MAY (preferably) be converted to lower case.
+       Lexical representations of language tags
+       MAY be case normalized,
+       (for example, by converting to lower case).
       </p>
 
     <p>A literal is a <dfn id="dfn-dir-lang-string">directional language-tagged string</dfn>
@@ -1817,15 +1817,16 @@
       to improve the example about distinguishing literals, IRIs, and blank nodes
       in <a href="#section-triples" class="sectionRef"></a>.</li>
     <li>Implementations were previously allowed to normalize language tags to lower case,
-      which made it ambiguous if two literals with language tags different only by case represented the same literal,
+      which made it ambiguous whether two literals with language tags
+      that differed only by case represented the same literal,
       or distinct literals.
-      RDF 1.2 requires that language tags must be unique to within case-senstivity
+      RDF 1.2 requires that language tags be case-insensitively unique 
       but does not specify the common formatting to be used.
-      Two literals that with the same lexical form and language tags different only by case
+      Two literals with the same lexical form and language tags that differ only by case
       are the same literal.
       Implementations can either follow the advice to normalize to lower case,
       use the recommended BCP47 format,
-      or something else, as long it is performed consistently.</li>
+      or do something else, as long it is performed consistently.</li>
   </ul>
 
   <p class="note">A detailed overview of the differences between RDF versions&nbsp;1.0

--- a/spec/index.html
+++ b/spec/index.html
@@ -1819,8 +1819,10 @@
     <li>Implementations were previously allowed to normalize language tags to lower case,
       which made it ambiguous if two literals with language tags different only by case represented the same literal,
       or distinct literals.
-      RDF 1.2 requires that language tags be case normalized,
-      but does not specify excactly how this is to be performed.
+      RDF 1.2 requires that language tags must be unique to within case-senstivity
+      but does not specify the common formatting to be used.
+      Two literals that with the same lexical form and language tags different only by case
+      are the same literal.
       Implementations can either follow the advice to normalize to lower case,
       use the recommended BCP47 format,
       or something else, as long it is performed consistently.</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -719,7 +719,8 @@
         language tag MUST be well-formed according to
         <a data-cite="bcp47#section-2.2.9">section 2.2.9</a>
         of [[!BCP47]],
-        and MUST be case normalized consistently (e.g., to lower case).</li>
+        and MUST be treated consistently, that is, in a case insensitive manner.
+        Two language tags are the same if they only differ by case.</li>
       <li>if and only if the <a>datatype IRI</a> is
         <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#dirLangString</code>,
         a non-empty <a>language tag</a>
@@ -733,7 +734,7 @@
       Lexical representations of language tags
       MUST be case normalized
       and MAY (preferably) be converted to lower case.
-      The value of language tags is always treated as being in lower case.</p>
+      </p>
 
     <p>A literal is a <dfn id="dfn-dir-lang-string">directional language-tagged string</dfn>
       if both the third element and fourth elements are present.

--- a/spec/index.html
+++ b/spec/index.html
@@ -718,7 +718,8 @@
         non-empty <dfn>language tag</dfn> as defined by [[!BCP47]]. The
         language tag MUST be well-formed according to
         <a data-cite="bcp47#section-2.2.9">section 2.2.9</a>
-        of [[!BCP47]].</li>
+        of [[!BCP47]],
+        and MUST be case normalized consistently (e.g., to lower case)..</li>
       <li>if and only if the <a>datatype IRI</a> is
         <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#dirLangString</code>,
         a non-empty <a>language tag</a>
@@ -729,8 +730,9 @@
 
     <p>A literal is a <dfn>language-tagged string</dfn> if the third element
       is present and the fourth element is not present.
-      Lexical representations of language tags MAY be converted
-      to lower case.
+      Lexical representations of language tags
+      MUST be case normalized
+      and MAY be converted to lower case.
       The value of language tags is always treated as being in lower case.</p>
 
     <p>A literal is a <dfn id="dfn-dir-lang-string">directional language-tagged string</dfn>
@@ -1813,6 +1815,14 @@
     <li>Minor edit
       to improve the example about distinguishing literals, IRIs, and blank nodes
       in <a href="#section-triples" class="sectionRef"></a>.</li>
+    <li>Language tags were previously allowed to be normalized to lower case,
+      which made it ambiguous if two literals with language tags different only by case represented the same literal,
+      or distinct literals.
+      RDF 1.2 requires that language tags be case normalized,
+      but does not specify excactly how this is to be performed.
+      Implementations can either follow the advice to normalize to lower case,
+      use the recommended BCP47 format,
+      or something else, as long it is performed consistently.</li>
   </ul>
 
   <p class="note">A detailed overview of the differences between RDF versions&nbsp;1.0


### PR DESCRIPTION
As described in https://github.com/w3c/rdf-concepts/issues/55#issuecomment-1836898816 requires that language tags be normalized, but not necessarily to lower case allowing implementations to use BCP47 format, for example.

Fixes #55.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/74.html" title="Last updated on Dec 14, 2023, 5:23 PM UTC (334ce35)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/74/54924d6...334ce35.html" title="Last updated on Dec 14, 2023, 5:23 PM UTC (334ce35)">Diff</a>