### PR TITLE
Change reference from RDFA-PRIMER to RDFA-CORE

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -460,7 +460,7 @@
 
     <p>An <dfn>RDF document</dfn> is a document that encodes an
       <a>RDF graph</a> or <a>RDF dataset</a> in a <dfn>concrete RDF syntax</dfn>,
-      such as Turtle [[RDF12-TURTLE]], RDFa [[RDFA-PRIMER]], JSON-LD [[JSON-LD11]], or
+      such as Turtle [[RDF12-TURTLE]], RDFa [[RDFA-CORE]], JSON-LD [[JSON-LD11]], or
       TriG [[RDF12-TRIG]]. RDF documents enable the exchange of RDF graphs and RDF
       datasets between systems.</p>
 


### PR DESCRIPTION
This PR is a https://www.w3.org/Consortium/Process/#class-2 change.

The example [concrete RDF syntaxes](https://www.w3.org/TR/rdf12-concepts/#dfn-concrete-rdf-syntax) mentioned refer to defined syntax specifications, except for RDFa, which refers to its Primer document. The PR switches the reference from RDFA-PRIMER to RDFA-CORE.

Given that the document derived from, RDF11-CONCEPTS, also made use of RDFA-PRIMER, this change can be seen as a correction or an errata.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/csarven/rdf-concepts/pull/75.html" title="Last updated on Dec 26, 2023, 10:33 PM UTC (1c8a526)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/75/54924d6...csarven:1c8a526.html" title="Last updated on Dec 26, 2023, 10:33 PM UTC (1c8a526)">Diff</a>