### PR TITLE
update my w3cid

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -20,7 +20,7 @@
 
       editors:  [
         { name: "Olaf Hartig", w3cid: "112469"},
-        { name: "Pierre-Antoine Champin", w3cid: "42931"},
+        { name: "Pierre-Antoine Champin", w3cid: "129656"},
         { name: "Gregg Kellogg", w3cid: "44770" },
       ],
 


### PR DESCRIPTION
the current w3cid is an old one, which is disabled. This now cause Echidna to fail.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/76.html" title="Last updated on Jan 12, 2024, 1:45 PM UTC (776bf69)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/76/53ca6ee...776bf69.html" title="Last updated on Jan 12, 2024, 1:45 PM UTC (776bf69)">Diff</a>