### PR TITLE
Proposal to adapt the abstract syntax to option 3

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1789,8 +1789,12 @@
   <ul>
     <li>Added <a href="#section-dataset-quad" class="sectionRef"></a>
       for informative definition of a <a>quad</a>.</li>
+    <!-- The following bullet point should be removed when Section 1.3 is changed
+         to introduce triple terms instead of quoted triples. -->
     <li>Added <a href="#section-quoted-triples" class="sectionRef"></a>
-      and definitions for <a>quoted triple</a> and <a>asserted triple</a>.</li>
+      <s>and definitions for <a>quoted triple</a> and <a>asserted triple</a></s>.</li>
+    <li>Added the notion of a <a>triple term</a> and extended the definition of
+      <a>RDF triple</a> to permit triple terms as objects.</li>
     <li>Added the <a>base direction</a> element as part of 
       a <a>literal</a>,
       and a description of its use in <a href="#section-text-direction" class="sectionRef"></a>.</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1798,7 +1798,7 @@
     <li>Added <a href="#section-dataset-quad" class="sectionRef"></a>
       for informative definition of a <a>quad</a>.</li>
     <li>Added <a href="#section-quoted-triples" class="sectionRef"></a>
-      <s>and definitions for <a>quoted triple</a> and <a>asserted triple</a></s>.</li>
+      <s>and definitions for <a>quoted triple</a> and <a>asserted triple</a></s>.
 
     <div class="issue" data-number="81">
       The notion of quoted triples is deprecated and will be removed again from this document. Currently, Section <a href="#section-quoted-triples" class="sectionRef"></a> still describes this notion. Once this section is changed to describe whatever new concept the WG settles on (currently, this may be <a>triple terms</a>---see the next bullet point), the previous bullet point can be removed and the addition of the then-rewritten section can be mentioned in the next bullet point.

--- a/spec/index.html
+++ b/spec/index.html
@@ -548,7 +548,7 @@
         or a <a>triple term</a>.</li>
     </ul>
 
-    <p>An <dfn>triple term</dfn> is a 3-tuple that is defined recursively as follows:</p>
+    <p>A <dfn>triple term</dfn> is a 3-tuple that is defined recursively as follows:</p>
 
     <ul>
       <li>
@@ -561,8 +561,8 @@
       <li>
         If |s| is an <a>IRI</a> or a <a>blank node</a>,
         |p| is an <a>IRI</a>, and
-        |t| is a <a>triple term</a>,
-        then (|s|, |p|, |t|) is a triple term.
+        |o| is a <a>triple term</a>,
+        then (|s|, |p|, |o|) is a triple term.
       </li>
     </ul>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -68,7 +68,7 @@
   </ul>
 
   <p>RDF 1.2 introduces <a>triple terms</a> as another kind of <a>RDF term</a>
-    which can be used as the <a>subject</a> or <a>object</a> of another <a>triple</a>.
+    which can be used as the <a>object</a> of another <a>triple</a>.
     RDF 1.2 also introduces <a>directional language-tagged strings</a>,
     which contain a <a>base direction</a> element that allows the
     initial text direction to be specified for presentation by a user agent.</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -67,7 +67,7 @@
       are comprised of a default graph and zero or more named graphs.</li>
   </ul>
 
-  <p>RDF 1.2 introduces <a>quoted triples</a> as another kind of <a>RDF term</a>
+  <p>RDF 1.2 introduces <a>triple terms</a> as another kind of <a>RDF term</a>
     which can be used as the <a>subject</a> or <a>object</a> of another <a>triple</a>.
     RDF 1.2 also introduces <a>directional language-tagged strings</a>,
     which contain a <a>base direction</a> element that allows the
@@ -130,7 +130,7 @@
 
     <p>There can be four kinds of <a>nodes</a> in an
       <a>RDF graph</a>: <a>IRIs</a>, <a>literals</a>,
-      <a>blank nodes</a>, and <a>quoted triples</a>.</p>
+      <a>blank nodes</a>, and <a>triple terms</a>.</p>
 
   </section>
 
@@ -492,12 +492,12 @@
   <ul>
     <li><dfn class="no-export lint-ignore">Full</dfn> conformance
       supports <a data-lt="RDF graph">graphs</a> and <a data-lt="RDF dataset">datasets</a>
-      containing <a>quoted triples</a>.
+      with <a>triples</a> that contain <a>triple terms</a>.
       Concrete syntaxes in which such graphs and datasets can be expressed include
       [[RDF12-N-TRIPLES]], [[RDF12-N-QUADS]], [[RDF12-TURTLE]], and [[RDF12-TRIG]].</li>
     <li><dfn class="no-export lint-ignore">Classic</dfn> conformance
-      only supports <a data-lt="RDF graph">graphs</a> or <a data-lt="RDF dataset">datasets</a>,
-      that do not contain <a>quoted triples</a>.</li>
+      only supports <a data-lt="RDF graph">graphs</a> or <a data-lt="RDF dataset">datasets</a>
+      with <a>triples</a> that do not contain <a>triple terms</a>.</li>
   </ul>
   <p class="ednote">The conformance levels described above are tentative,
     and still the subject of group discussion. An alternative to conformance
@@ -538,53 +538,59 @@
   <section id="section-triples">
     <h3>Triples</h3>
 
-    <p>An <dfn data-local-lt="triple">RDF triple</dfn> is a 3-tuple that is defined recursively as follows:</p>
+    <p>An <dfn data-local-lt="triple">RDF triple</dfn> (usually called "triple")
+      is a 3-tuple (|s|, |p|, |o|) where:</p>
+
+    <ul>
+      <li>|s| is an <a>IRI</a> or a <a>blank node</a>,</li>
+      <li>|p| is an <a>IRI</a>, and</li>
+      <li>|o| is an <a>IRI</a>, a <a>blank node</a>, a <a>literal</a>,
+        or a <a>triple term</a>.</li>
+    </ul>
+
+    <p>An <dfn>triple term</dfn> is a 3-tuple that is defined recursively as follows:</p>
 
     <ul>
       <li>
         If |s| is an <a>IRI</a> or a <a>blank node</a>,
         |p| is an <a>IRI</a>, and
         |o| is an <a>IRI</a>, a <a>blank node</a>, or a <a>literal</a>,
-        then (|s|, |p|, |o|) is an RDF triple.
+        then (|s|, |p|, |o|) is a triple term.
       </li>
 
       <li>
-        If |t| and <var>t'</var> are <a>RDF triples</a>,
-        |s| is an <a>IRI</a> or a <a>blank node</a>,
+        If |s| is an <a>IRI</a> or a <a>blank node</a>,
         |p| is an <a>IRI</a>, and
-        |o| is an <a>IRI</a>, a <a>blank node</a>, or a <a>literal</a>,
-        then (|t|, |p|, |o|), (|s|, |p|, |t|), and (|t|, |p|, <var>t'</var>) are RDF triples.
+        |t| is a <a>triple term</a>,
+        then (|s|, |p|, |t|) is a triple term.
       </li>
     </ul>
-
-    <p>"RDF triple" is usually written "<a>triple</a>".<p>
 
     <p>Given a <a>triple</a> (|s|, |p|, |o|),
       |s| is called the <dfn>subject</dfn> of the triple,
       |p| is called the <dfn>predicate</dfn> of the triple, and
-      |o| is called the <dfn>object</dfn> of the triple.</p>
+      |o| is called the <dfn>object</dfn> of the triple.
+      Similarly, given a <a>triple term</a> (|s|, |p|, |o|),
+      |s| is called the <em>subject</em> of the triple term,
+      |p| is called the <em>predicate</em> of the triple term, and
+      |o| is called the <em>object</em> of the triple term.</p>
 
-    <p>When an <a>RDF triple</a> is used as the <a>subject</a> or <a>object</a> of a triple, this occurrence of
-      the triple is called a <dfn data-local-lt="quoted">quoted triple</dfn>.</p>
+    <p class="note">While, syntactically, the notion of an <a>RDF triple</a>
+      and the notion of a <a>triple term</a> are the same, they represent
+      different concepts. RDF triples are the members of <a>RDF graphs</a>,
+      whereas triple terms can be used as components of RDF triples.</p>
 
-    <p class="note">By the given definitions,
-      the <a>subject</a> of an <a>RDF triple</a> may be either an <a>IRI</a>,
-      a <a>blank node</a>, or a <a>quoted triple</a>;
-      the <a>predicate</a> of an <a>RDF triple</a> may only be an <a>IRI</a>;
-      the <a>object</a> of an <a>RDF triple</a> may be either an <a>IRI</a>,
-      a <a>blank node</a>, a <a>literal</a> or a <a>quoted triple</a>.</p>
-
-    <p class="note">The definition of <a>quoted triple</a> is recursive.
-      That is, a <a>quoted triple</a> can itself have a
-      <a>subject</a> or <a>object</a> component which is another <a>quoted triple</a>.
-      However, by this definition, cycles of <a>quoted triples</a> cannot be created.</p>
+    <p class="note">The definition of <a>triple term</a> is recursive.
+      That is, a <a>triple term</a> can itself have an
+      <a>object</a> component which is another <a>triple term</a>.
+      However, by this definition, cycles of <a>triple terms</a> cannot be created.</p>
 
     <p><a>IRIs</a>, <a>literals</a>,
-      <a>blank nodes</a>, and <a>quoted triples</a> are collectively known as
+      <a>blank nodes</a>, and <a>triple terms</a> are collectively known as
       <span id="dfn-rdf-terms"><!-- obsolete term--></span><dfn data-lt="rdf term">RDF terms</dfn>.</p>
 
     <p><a>IRIs</a>, <a>literals</a>,
-      <a>blank nodes</a>, and <a>quoted triples</a> are distinct and distinguishable.
+      <a>blank nodes</a>, and <a>triple terms</a> are distinct and distinguishable.
       For example, a literal with the string <code>http://example.org/</code> as
       its <a>lexical form</a>
       is not equal to the IRI <code>http://example.org/</code>,
@@ -592,17 +598,9 @@
       <code>http://example.org/</code>.</p>
 
     <p>The set of <span id="dfn-nodes"><!-- obsolete term--></span><dfn data-lt="node">nodes</dfn> of an <a>RDF graph</a>
-      is the set of <a>subjects</a> and <a>objects</a> of <a>triples</a> in the graph.
+      is the set of <a>subjects</a> and <a>objects</a> of the <a>triples</a> in the graph.
       It is possible for a predicate IRI to also occur as a node in
       the same graph.</p>
-
-    <p>An <dfn data-local-lt="asserted">asserted triple</dfn>
-      is an <a>RDF triple</a> that is an element of an <a>RDF graph</a>.</p>
-
-    <p class="note">In an <a>RDF graph</a>,
-      a <a>triple</a> may occur as either a <a>quoted triple</a>, an 
-      <a>asserted triple</a>, or both.</p>
-  </section>
 
   <section id="section-IRIs">
     <h3>IRIs</h3>

--- a/spec/index.html
+++ b/spec/index.html
@@ -179,7 +179,7 @@
       As the WG has moved away from the notion of quoted triples, this section needs to be changed such that it does not mention quoted triples anymore but, instead, describes whatever new concept the WG settles on (e.g., <a>triple terms</a>).
     </p>
 
-    <p>A <a>quoted triple</a> is an <a>RDF term</a> with the components of
+    <p>A <dfn>quoted triple</dfn> is an <a>RDF term</a> with the components of
       an <a>RDF triple</a>, which can be used as the <a>subject</a> or <a>object</a>
       of another triple.</p>
 
@@ -538,6 +538,10 @@
   <h2>RDF Graphs</h2>
 
   <p>An <dfn>RDF graph</dfn> is a set of <a>RDF triples</a>.</p>
+
+  <p class=issue>
+    Do we still need to define <dfn>asserted triple</dfn>?.
+  </p>
 
   <section id="section-triples">
     <h3>Triples</h3>

--- a/spec/index.html
+++ b/spec/index.html
@@ -175,6 +175,10 @@
   <section id="section-quoted-triples">
     <h3>Quoted Triples</h3>
 
+    <p class="issue" data-number="81">
+      As the WG has moved away from the notion of quoted triples, this section needs to be changed such that it does not mention quoted triples anymore but, instead, describes whatever new concept the WG settles on (e.g., <a>triple terms</a>).
+    </p>
+
     <p>A <a>quoted triple</a> is an <a>RDF term</a> with the components of
       an <a>RDF triple</a>, which can be used as the <a>subject</a> or <a>object</a>
       of another triple.</p>
@@ -1789,10 +1793,13 @@
   <ul>
     <li>Added <a href="#section-dataset-quad" class="sectionRef"></a>
       for informative definition of a <a>quad</a>.</li>
-    <!-- The following bullet point should be removed when Section 1.3 is changed
-         to introduce triple terms instead of quoted triples. -->
     <li>Added <a href="#section-quoted-triples" class="sectionRef"></a>
       <s>and definitions for <a>quoted triple</a> and <a>asserted triple</a></s>.</li>
+
+    <div class="issue" data-number="81">
+      The notion of quoted triples is deprecated and will be removed again from this document. Currently, Section <a href="#section-quoted-triples" class="sectionRef"></a> still describes this notion. Once this section is changed to describe whatever new concept the WG settles on (currently, this may be <a>triple terms</a>---see the next bullet point), the previous bullet point can be removed and the addition of the then-rewritten section can be mentioned in the next bullet point.
+    </div>
+
     <li>Added the notion of a <a>triple term</a> and extended the definition of
       <a>RDF triple</a> to permit triple terms as objects.</li>
     <li>Added the <a>base direction</a> element as part of 

--- a/spec/index.html
+++ b/spec/index.html
@@ -601,7 +601,7 @@
       is the set of <a>subjects</a> and <a>objects</a> of the <a>triples</a> in the graph.
       It is possible for a predicate IRI to also occur as a node in
       the same graph.</p>
-
+  </section>
   <section id="section-IRIs">
     <h3>IRIs</h3>
 


### PR DESCRIPTION
Given the consensus that we reached in yesterday's call, here is a proposal on how to change the relevant definitions in RDF Concepts in order to capture [Option 3](https://github.com/w3c/rdf-star-wg/blob/main/docs/seeking-consensus-2024-01.html).

Some remarks about this PR:
1. I am currently using the term "triple term" in this proposal while the term "triple descriptor" has been floating around as an alternative name for the same concept. Personally, I like "triple term" more but, of course, I am open to replace "triple term" by "triple descriptor" in this PR if there is consensus in the group towards the latter.
2. At the end of yesterday's call, there was a brief discussion whether the definition of triple terms should be recursive (i.e., whether a triple term may contain another triple term). The current definition in this PR is recursive. I defined it this way because of @pchampin's argument that, without recursion, it becomes impossible to talk about `rdf:nameOf` triples which have a triple term in their object position. Of course, if the group decides against such a recursive definition, this PR can easily be adapted to make the definition non-recursive.
3. I have separated the definitions of "RDF triple" and "triple term" from one another even if these two definitions are essentially the same (syntactically, an RDF triple and a triple term are exactly the same thing). My rationale for this separation is to make it more obvious that these are two different concepts. I have also added a brief 'Note' on this topic.
4. I have removed the definition of "asserted triple" because I think, by clearly separating the notion of an RDF triple from the notion of a triple term, it becomes obsolete to talk about asserted triples. Every triple (in a graph) is asserted; triple terms are not members of graphs.
5. This PR changes only the definitions. I explicitly decided not to touch Section 1.3, which (currently) provides an informal introduction of quoted triples. We will certainly have to change that section as well, but I think that should be a different PR. We should first make sure that we have the definitions right.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/78.html" title="Last updated on Mar 7, 2024, 6:14 PM UTC (497bbb2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/78/2ff13d4...497bbb2.html" title="Last updated on Mar 7, 2024, 6:14 PM UTC (497bbb2)">Diff</a>