### PR TITLE
The set of DOM document fragments

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1402,7 +1402,7 @@
       <dd>is <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML</code>.</dd>
 
       <dt id="HTML-value-space">The <a>value space</a></dt>
-      <dd>is a set of DOM
+      <dd>is the set of DOM
         <a data-cite="DOM#interface-documentfragment"><code>DocumentFragment</code></a>
         nodes [[DOM]]. Two
         <a data-cite="DOM#interface-documentfragment"><code>DocumentFragment</code></a>
@@ -1461,7 +1461,7 @@
         a document conforming to [[[XML-NAMES]]] [[XML-NAMES]].</dd>
 
       <dt id="XMLLiteral-value-space">The <a>value space</a></dt>
-        <dd>is a set of DOM
+        <dd>is the set of DOM
         <a data-cite="DOM#interface-documentfragment"><code>DocumentFragment</code></a>
         nodes [[DOM]]. Two
         <a data-cite="DOM#interface-documentfragment"><code>DocumentFragment</code></a>


### PR DESCRIPTION
"a set of ..." reads as if it is some choice.

There is only one set of all XML document fragments using the definition of equals quoted.

The lexical space (XMLLiteral) is already a "the set" wording. 

rdf:HTML does not mention the lexical space.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/84.html" title="Last updated on Apr 22, 2024, 6:21 PM UTC (deb905c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/84/709a50a...deb905c.html" title="Last updated on Apr 22, 2024, 6:21 PM UTC (deb905c)">Diff</a>