### PR TITLE
Fix reference to INFRA#map-entry.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1532,7 +1532,7 @@
         <a>strings</a>,
         numbers (<a data-cite="XMLSCHEMA11-2#double"><strong>xsd:double</strong></a>),
         <a data-cite="INFRA#ordered-map">maps</a>
-        (mapping <a>strings</a> to values in the <a href="#JSON-value-space">value space</a> where the order of <a data-cite="INFRA#entry">map entries</a> is not significant),
+        (mapping <a>strings</a> to values in the <a href="#JSON-value-space">value space</a> where the order of <a data-cite="INFRA#map-entry">map entries</a> is not significant),
         <a data-cite="INFRA#list">lists</a>
         (of values in the <a href="#JSON-value-space">value space</a>), and
         literal values (<a data-cite="INFRA#boolean">`true`, `false`</a>, and <a data-cite="INFRA#nulls">`null`</a>)
@@ -1548,7 +1548,7 @@
               in |a| is equal the <a data-cite="INFRA#list-item">item</a>
               at the corresponding index in |b|,
               and both |a| and |b| have the same <a data-cite="INFRA#list-size">size</a>; or</li>
-            <li>if they are both <a data-cite="INFRA#ordered-map">maps</a> with equal <a data-cite="INFRA#entry">entries</a>
+            <li>if they are both <a data-cite="INFRA#ordered-map">maps</a> with equal <a data-cite="INFRA#map-entry">entries</a>
               – meaning that both |a| and |b| have the same <a data-cite="INFRA#map-size">size</a>,
               and for each entry <var>e<sub>a</sub></var> in |a|
               there is an entry <var>e<sub>b</sub></var> in |b|


### PR DESCRIPTION
Fixes #93.

Note, still doesn't use the `[=infra/map-entry=]` syntax consistent with our other usage.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/94.html" title="Last updated on Jul 4, 2024, 5:34 PM UTC (44b066e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/94/4ab0df5...44b066e.html" title="Last updated on Jul 4, 2024, 5:34 PM UTC (44b066e)">Diff</a>