### PR TITLE
GH-100: Literal equality and language tags

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -747,9 +747,9 @@
 
     <p>A literal is a <dfn>language-tagged string</dfn> if the third element
       is present and the fourth element is not present.
-       Lexical representations of language tags
-       MAY be case normalized,
-       (for example, by converting to lower case).
+      Lexical representations of language tags MAY be case normalized,
+      (for example, by canonicalizing as defined by 
+      <a data-cite="bcp47#section-4.5">BCP 47 section 4.5</a>).
       </p>
 
     <p>A literal is a <dfn id="dfn-dir-lang-string">directional language-tagged string</dfn>
@@ -804,12 +804,19 @@
 
     <p><dfn data-local-lt="term-equal">Literal term equality</dfn>:
       Two literals are term-equal (the same <a>RDF literal</a>)
-      if and only if the two <a>lexical forms</a>,
-      the two <a>datatype IRIs</a>,
-      the two <a>language tags</a> (if any), and
-      the two <a>base directions</a> (if any) compare equal,
-      using <a data-cite="I18N-GLOSSARY#dfn-case-sensitive">case sensitive matching</a>
-      (see description of string comparison in <a href="#rdf-strings" class="sectionRef"></a>).
+      if and only if:
+      <ul>
+        <li>the two <a>lexical forms</a> compare equal</li>
+        <li>the two <a>datatype IRIs</a> compare equal</li>
+        <li>the two <a>language tags</a> (if any) compare equal</li>
+        <li>the two <a>base directions</a> (if any) compare equal</li>
+      </ul>
+      Comparison is performed using 
+      <a data-cite="I18N-GLOSSARY#dfn-case-sensitive">case sensitive matching</a>
+      (see description of string comparison in 
+      <a href="#rdf-strings" class="sectionRef"></a>)
+      except for language tags, where the comparison is performed using 
+      <a data-cite="I18N-GLOSSARY#dfn-case-sensitive">ASCII case-insensitive matching</a>.
       Thus, two literals can have the same value
       without being the same <a>RDF term</a>.
       For example:</p>


### PR DESCRIPTION
This closes #100.

This suggestion turns the list into bullet points.

Notes:
It is written as "case sensitive" in i18n-glossary.
It is "ASCII case-insenitive" in i18n-glossary.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/105.html" title="Last updated on Oct 24, 2024, 7:34 AM UTC (9c5ef40)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/105/eefa2a6...9c5ef40.html" title="Last updated on Oct 24, 2024, 7:34 AM UTC (9c5ef40)">Diff</a>