### PR TITLE
Add text about text directionality to the note in rdf:HTML.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1440,7 +1440,7 @@
 
     <p class="note" id="note-html">
       Any language annotation (<code>lang="…"</code>),
-      text directionality annotation (<code>dir="..."</code>), or
+      text directionality annotation (<code>dir="…"</code>), or
       XML namespaces (<code>xmlns</code>) desired in the HTML content
       must be included explicitly in the HTML literal. Relative URLs
       in attributes such as <code>href</code> do not have a well-defined

--- a/spec/index.html
+++ b/spec/index.html
@@ -1439,7 +1439,8 @@
     </dl>
 
     <p class="note" id="note-html">
-      Any language annotation (<code>lang="…"</code>) or
+      Any language annotation (<code>lang="…"</code>),
+      text directionality annotation (<code>dir="..."</code>), or
       XML namespaces (<code>xmlns</code>) desired in the HTML content
       must be included explicitly in the HTML literal. Relative URLs
       in attributes such as <code>href</code> do not have a well-defined


### PR DESCRIPTION
Fixes #102.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/107.html" title="Last updated on Oct 22, 2024, 8:57 PM UTC (f4d17bf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/107/eefa2a6...f4d17bf.html" title="Last updated on Oct 22, 2024, 8:57 PM UTC (f4d17bf)">Diff</a>