### PR TITLE
GH-110: Section for definition of Triple Terms

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -172,68 +172,6 @@
       exists, without explicitly naming it.</p>
   </section>
 
-  <section id="section-triple-terms-reification">
-    <h3>Triple Terms and Reification</h3>
-
-    <p>A <a>triple term</a> is an <a>RDF term</a> with the components of
-      an <a>RDF triple</a>, which can be used as the <a>object</a>
-      of another triple.</p>
-
-    <p>A <a>triple term</a> is not necessarily asserted, allowing
-      statements to be made about other statements that may not be
-      asserted within an <a>RDF graph</a>.
-      This allows statements to be made about relationships that may be contradictory.
-      For a <a>triple term</a> to be asserted,
-      it must also appear in a graph as an <a>asserted triple</a>.</p>
-
-    <p>A <a>triple term</a> can be used as the object of a <a>triple</a> with the predicate <code>rdf:reifies</code>;
-      such a <a>triple</a> is then a <dfn>reifying triple</dfn>.
-      The <a>subject</a> of that <a>triple</a> is called a <dfn>reifier</dfn>.
-      Assertions on the <a>triple term</a> are made using the <a>reifier</a>.
-      A concrete syntax may provide a special notation for specifying <a>reifying triples</a>.</p>
-
-    <p class="note">Using the <a>reifier</a> as an indirect way of referencing a <a>triple term</a>
-      allows multiple groups of assertions to be separated from each other,
-      which might be necessary if the same <a>triple term</a> was derived from different sources.
-      Assertions are always made using the <a>reifier</a>, which can be the <a>subject</a> or <a>object</a>
-      of different triples.
-      Concrete syntaxes, such as Turtle [[RDF12-TURTLE]],
-      may have shortcuts for capturing a <a>triple term</a> with its <a>reifier</a>.</p>
-
-    <p>The following diagram represents a statement and a reification of an unasserted <a>triple term</a>.</p>
-
-    <figure id="fig-triple-term">
-      <a href="triple-term.svg">
-        <!-- A version of this graphic can be found at https://docs.google.com/drawings/d/1RP9Nw5GCNjduWSXZj_EZ8FaAc7p_N-WVmzJ0syvum1k -->
-        <img src="triple-term.svg"
-             alt="An RDF graph containing a triple that references an unasserted triple term (with grey background) via a reifier"
-             style="width:70%"
-             aria-describedby="fig-triple-term-alt"/>
-      </a>
-      <figcaption id="fig-triple-term-alt">
-        An <a>RDF graph</a> containing a <a>triple</a> that references an unasserted <a>triple term</a> (with grey background) via a <a>reifier</a>.
-      </figcaption>
-    </figure>
-
-    <p>A variation on the graph shown in <a href="#fig-triple-term"></a> can be described
-      where the <a>triple term</a> is also <a data-lt="asserted triple">asserted</a>.</p>
-
-    <figure id="fig-asserted-triple-term">
-      <a href="asserted-triple-term.svg">
-        <!-- A version of this graphic can be found at https://docs.google.com/drawings/d/1gAHQj4wk87tmeHf4-wnxdgmjq3T05_ovrJq0V-1VXKw -->
-        <img src="asserted-triple-term.svg"
-             alt="An RDF graph containing a triple that references an triple term, which is also asserted, via a reifier"
-             style="width:70%"
-             aria-describedby="fig-asserted-triple-term-alt"/>
-      </a>
-      <figcaption id="fig-asserted-triple-term-alt">
-        An <a>RDF graph</a> containing a <a>triple</a> that references an <a>triple term</a>, which is also asserted, via a <a>reifier</a>.
-      </figcaption>
-    </figure>
-
-    <p>Note that a <a>triple term</a> may also have another <a>triple term</a> as an <a>object</a>.</p>
-  </section>
-
   <section id="referents">
     <h3>The Referent of an IRI</h3>
 
@@ -344,6 +282,68 @@
     <p>The term “<dfn class="lint-ignore">namespace</dfn>” on its own does not have a
       well-defined meaning in the context of RDF, but is sometimes informally
       used to mean “<a>namespace IRI</a>” or “<a>RDF vocabulary</a>”.</p>
+  </section>
+
+  <section id="section-triple-terms-reification">
+    <h3>Triple Terms and Reification</h3>
+
+    <p>A <a>triple term</a> is an <a>RDF term</a> with the components of
+      an <a>RDF triple</a>, which can be used as the <a>object</a>
+      of another triple.</p>
+
+    <p>A <a>triple term</a> is not necessarily asserted, allowing
+      statements to be made about other statements that may not be
+      asserted within an <a>RDF graph</a>.
+      This allows statements to be made about relationships that may be contradictory.
+      For a <a>triple term</a> to be asserted,
+      it must also appear in a graph as an <a>asserted triple</a>.</p>
+
+    <p>A <a>triple term</a> can be used as the object of a <a>triple</a> with the predicate <code>rdf:reifies</code>;
+      such a <a>triple</a> is then a <dfn>reifying triple</dfn>.
+      The <a>subject</a> of that <a>triple</a> is called a <dfn>reifier</dfn>.
+      Assertions on the <a>triple term</a> are made using the <a>reifier</a>.
+      A concrete syntax may provide a special notation for specifying <a>reifying triples</a>.</p>
+
+    <p class="note">Using the <a>reifier</a> as an indirect way of referencing a <a>triple term</a>
+      allows multiple groups of assertions to be separated from each other,
+      which might be necessary if the same <a>triple term</a> was derived from different sources.
+      Assertions are always made using the <a>reifier</a>, which can be the <a>subject</a> or <a>object</a>
+      of different triples.
+      Concrete syntaxes, such as Turtle [[RDF12-TURTLE]],
+      may have shortcuts for capturing a <a>triple term</a> with its <a>reifier</a>.</p>
+
+    <p>The following diagram represents a statement and a reification of an unasserted <a>triple term</a>.</p>
+
+    <figure id="fig-triple-term">
+      <a href="triple-term.svg">
+        <!-- A version of this graphic can be found at https://docs.google.com/drawings/d/1RP9Nw5GCNjduWSXZj_EZ8FaAc7p_N-WVmzJ0syvum1k -->
+        <img src="triple-term.svg"
+             alt="An RDF graph containing a triple that references an unasserted triple term (with grey background) via a reifier"
+             style="width:70%"
+             aria-describedby="fig-triple-term-alt"/>
+      </a>
+      <figcaption id="fig-triple-term-alt">
+        An <a>RDF graph</a> containing a <a>triple</a> that references an unasserted <a>triple term</a> (with grey background) via a <a>reifier</a>.
+      </figcaption>
+    </figure>
+
+    <p>A variation on the graph shown in <a href="#fig-triple-term"></a> can be described
+      where the <a>triple term</a> is also <a data-lt="asserted triple">asserted</a>.</p>
+
+    <figure id="fig-asserted-triple-term">
+      <a href="asserted-triple-term.svg">
+        <!-- A version of this graphic can be found at https://docs.google.com/drawings/d/1gAHQj4wk87tmeHf4-wnxdgmjq3T05_ovrJq0V-1VXKw -->
+        <img src="asserted-triple-term.svg"
+             alt="An RDF graph containing a triple that references an triple term, which is also asserted, via a reifier"
+             style="width:70%"
+             aria-describedby="fig-asserted-triple-term-alt"/>
+      </a>
+      <figcaption id="fig-asserted-triple-term-alt">
+        An <a>RDF graph</a> containing a <a>triple</a> that references an <a>triple term</a>, which is also asserted, via a <a>reifier</a>.
+      </figcaption>
+    </figure>
+
+    <p>Note that a <a>triple term</a> may also have another <a>triple term</a> as an <a>object</a>.</p>
   </section>
 
   <section id="change-over-time">
@@ -831,7 +831,7 @@
 
   <section id="section-triple-terms">
     <h3>Triple Terms</h3>
-    
+
     <p>A <dfn>triple term</dfn> is a 3-tuple that is defined recursively as follows:</p>
 
     <ul>
@@ -1066,7 +1066,7 @@
 
   <section id="section-dataset-quad" class="informative">
     <h3>Dataset as a Set of Quads</h3>
-    
+
     <p>A <dfn>quad</dfn> is a <a>triple</a> associated with an optional <a>graph name</a>
       and is used when referring to triples within an <a>RDF dataset</a>.
     </p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -172,8 +172,8 @@
       exists, without explicitly naming it.</p>
   </section>
 
-  <section id="section-triple-terms">
-    <h3>Triple Terms</h3>
+  <section id="section-triple-terms-reification">
+    <h3>Triple Terms and Reification</h3>
 
     <p>A <a>triple term</a> is an <a>RDF term</a> with the components of
       an <a>RDF triple</a>, which can be used as the <a>object</a>
@@ -537,7 +537,6 @@
   </section>
 </section>
 
-
 <section id="section-rdf-graph">
   <h2>RDF Graphs</h2>
 
@@ -558,50 +557,6 @@
         or a <a>triple term</a>.</li>
     </ul>
 
-    <p>A <dfn>triple term</dfn> is a 3-tuple that is defined recursively as follows:</p>
-
-    <ul>
-      <li>
-        If |s| is an <a>IRI</a> or a <a>blank node</a>,
-        |p| is an <a>IRI</a>, and
-        |o| is an <a>IRI</a>, a <a>blank node</a>, or a <a>literal</a>,
-        then (|s|, |p|, |o|) is a triple term.
-      </li>
-
-      <li>
-        If |s| is an <a>IRI</a> or a <a>blank node</a>,
-        |p| is an <a>IRI</a>, and
-        |o| is a <a>triple term</a>,
-        then (|s|, |p|, |o|) is a triple term.
-      </li>
-    </ul>
-
-    <p>Given a <a>triple</a> (|s|, |p|, |o|),
-      |s| is called the <dfn>subject</dfn> of the triple,
-      |p| is called the <dfn>predicate</dfn> of the triple, and
-      |o| is called the <dfn>object</dfn> of the triple.
-      Similarly, given a <a>triple term</a> (|s|, |p|, |o|),
-      |s| is called the <em>subject</em> of the triple term,
-      |p| is called the <em>predicate</em> of the triple term, and
-      |o| is called the <em>object</em> of the triple term.</p>
-
-    <p class="note">While, syntactically, the notion of an <a>RDF triple</a>
-      and the notion of a <a>triple term</a> are the same, they represent
-      different concepts. RDF triples are the members of <a>RDF graphs</a>,
-      whereas triple terms can be used as components of RDF triples.</p>
-
-    <p class="note">The definition of <a>triple term</a> is recursive.
-      That is, a <a>triple term</a> can itself have an
-      <a>object</a> component which is another <a>triple term</a>.
-      However, by this definition, cycles of <a>triple terms</a> cannot be created.</p>
-
-    <p class="note">Every <a>triple</a> with a <a>triple term</a> as its object SHOULD
-      use <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies</code> (<code>rdf:reifies</code>)
-      as its <a>predicate</a>.
-      Every <a>triple</a> whose <a>object</a> is not a <a>triple term</a> SHOULD NOT
-      use <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies</code> (<code>rdf:reifies</code>)
-      as its <a>predicate</a>.</p>
-
     <p><a>IRIs</a>, <a>literals</a>,
       <a>blank nodes</a>, and <a>triple terms</a> are collectively known as
       <span id="dfn-rdf-terms"><!-- obsolete term--></span><dfn data-lt="rdf term">RDF terms</dfn>.</p>
@@ -619,6 +574,7 @@
       It is possible for a predicate IRI to also occur as a node in
       the same graph.</p>
   </section>
+
   <section id="section-IRIs">
     <h3>IRIs</h3>
 
@@ -838,39 +794,6 @@
       same literal <a>RDF terms</a> and are not
       <a>term-equal</a> because their
       <a>lexical forms</a> differ.</p>
-
-    <section id="section-text-direction" class="informative">
-      <h3>Initial Text Direction</h3>
-
-      <p>The <a>base direction</a> of a <a>directional language-tagged string</a>
-        provides a means of establishing the initial direction of text,
-        including text which is a mixture of right-to-left and left-to-right scripts.
-        The [=Unicode Bidirectional Algorithm=] [[?I18N-Glossary]] provides support for automatically rendering
-        a sequence of characters in logical order,
-        so that they are visually ordered as expected,
-        but this is not sufficient to correctly render bidirectional text.</p>
-
-       <p>For example, some text with a language tag "`he`" might be displayed
-         in a left-to-right context (such as an English web page) as
-         <bdi dir="ltr">פעילות הבינאום, W3C</bdi>, which is incorrect. When provided
-         to a user agent including base direction information (such as using
-         HTML's `dir` attribute) it can then be correctly presented as:
-       </p>
-       <div lang="he" dir="rtl">פעילות הבינאום, W3C</div>
-
-       <p>In the absence of an explicit initial text direction,
-         the [=Unicode Bidirectional Algorithm=] detects the text direction from the content.
-         This depends on the first strongly directional character in the text
-         or on the context.
-         To avoid [=spillover effects=], users need to employ [=bidi isolation=] 
-         whenever text is inserted into a larger document.
-         For example,
-         &quot;<code>&lt;bdi lang="he"&gt;ספרים בינלאומיים!&lt;/bdi&gt;</code>&quot;
-         displays the Hebrew characters in a right-to-left fashion
-         — i.e., as &quot;<bdi lang="he">ספרים בינלאומיים!</bdi>&quot;
-         — while they would be stored in memory as
-         &quot;<bdo dir="ltr" lang="he">ספרים בינלאומיים!</bdo>&quot;</p>
-    </section>
   </section>
 
   <section id="section-blank-nodes">
@@ -904,6 +827,87 @@
       In the interest of consistency, the use of this alternative
       term is discouraged now.</p>
     </div>
+  </section>
+
+  <section id="section-triple-terms">
+    <h3>Triple Terms</h3>
+    
+    <p>A <dfn>triple term</dfn> is a 3-tuple that is defined recursively as follows:</p>
+
+    <ul>
+      <li>
+        If |s| is an <a>IRI</a> or a <a>blank node</a>,
+        |p| is an <a>IRI</a>, and
+        |o| is an <a>IRI</a>, a <a>blank node</a>, or a <a>literal</a>,
+        then (|s|, |p|, |o|) is a triple term.
+      </li>
+
+      <li>
+        If |s| is an <a>IRI</a> or a <a>blank node</a>,
+        |p| is an <a>IRI</a>, and
+        |o| is a <a>triple term</a>,
+        then (|s|, |p|, |o|) is a triple term.
+      </li>
+    </ul>
+
+    <p>Given a <a>triple</a> (|s|, |p|, |o|),
+      |s| is called the <dfn>subject</dfn> of the triple,
+      |p| is called the <dfn>predicate</dfn> of the triple, and
+      |o| is called the <dfn>object</dfn> of the triple.
+      Similarly, given a <a>triple term</a> (|s|, |p|, |o|),
+      |s| is called the <em>subject</em> of the triple term,
+      |p| is called the <em>predicate</em> of the triple term, and
+      |o| is called the <em>object</em> of the triple term.</p>
+
+    <p class="note">While, syntactically, the notion of an <a>RDF triple</a>
+      and the notion of a <a>triple term</a> are the same, they represent
+      different concepts. RDF triples are the members of <a>RDF graphs</a>,
+      whereas triple terms can be used as components of RDF triples.</p>
+
+    <p class="note">The definition of <a>triple term</a> is recursive.
+      That is, a <a>triple term</a> can itself have an
+      <a>object</a> component which is another <a>triple term</a>.
+      However, by this definition, cycles of <a>triple terms</a> cannot be created.</p>
+
+    <p class="note">Every <a>triple</a> with a <a>triple term</a> as its object SHOULD
+      use <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies</code> (<code>rdf:reifies</code>)
+      as its <a>predicate</a>.
+      Every <a>triple</a> whose <a>object</a> is not a <a>triple term</a> SHOULD NOT
+      use <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies</code> (<code>rdf:reifies</code>)
+      as its <a>predicate</a>.</p>
+  </section>
+
+  <section id="section-text-direction" class="informative">
+    <h3>Initial Text Direction</h3>
+
+    <p>The <a>base direction</a> of a <a>directional language-tagged string</a>
+      provides a means of establishing the initial direction of text,
+      including text which is a mixture of right-to-left and left-to-right scripts.
+      The [=Unicode Bidirectional Algorithm=] [[?I18N-Glossary]] provides support for automatically rendering
+      a sequence of characters in logical order,
+      so that they are visually ordered as expected,
+      but this is not sufficient to correctly render bidirectional text.</p>
+
+    <p>For example, some text with a language tag "`he`" might be displayed
+      in a left-to-right context (such as an English web page) as
+      <bdi dir="ltr">פעילות הבינאום, W3C</bdi>, which is incorrect. When provided
+      to a user agent including base direction information (such as using
+      HTML's `dir` attribute) it can then be correctly presented as:
+    </p>
+    <div lang="he" dir="rtl">פעילות הבינאום, W3C</div>
+
+    <p>In the absence of an explicit initial text direction,
+      the [=Unicode Bidirectional Algorithm=] detects the text direction from the content.
+      This depends on the first strongly directional character in the text
+      or on the context.
+      To avoid [=spillover effects=], users need to employ [=bidi isolation=] 
+      whenever text is inserted into a larger document.
+      For example,
+      &quot;<code>&lt;bdi lang="he"&gt;ספרים בינלאומיים!&lt;/bdi&gt;</code>&quot;
+      displays the Hebrew characters in a right-to-left fashion
+      — i.e., as &quot;<bdi lang="he">ספרים בינלאומיים!</bdi>&quot;
+      — while they would be stored in memory as
+      &quot;<bdo dir="ltr" lang="he">ספרים בינלאומיים!</bdo>&quot;</p>
   </section>
 
   <section id="section-skolemization">
@@ -1857,7 +1861,7 @@
   <ul>
     <li>Added <a href="#section-dataset-quad" class="sectionRef"></a>
       for informative definition of a <a>quad</a>.</li>
-   <li>Added <a href="#section-triple-terms" class="sectionRef"></a>
+   <li>Added <a href="#section-triple-terms-reification" class="sectionRef"></a>
       and definitions for <a>triple term</a> and <a>asserted triple</a>
       and extended the definition of
       <a>RDF triple</a> to permit triple terms as objects.

--- a/spec/index.html
+++ b/spec/index.html
@@ -347,7 +347,7 @@
   </section>
 
   <section id="change-over-time">
-    <h2>RDF and Change over Time</h2>
+    <h3>RDF and Change over Time</h3>
 
     <p>The RDF data model is <em>atemporal</em>: <a>RDF graphs</a>
       are static snapshots of information.</p>
@@ -465,7 +465,7 @@
   </section>
 
   <section id="rdf-documents">
-    <h2>RDF Documents and Syntaxes</h2>
+    <h3>RDF Documents and Syntaxes</h3>
 
     <p>An <dfn>RDF document</dfn> is a document that encodes an
       <a>RDF graph</a> or <a>RDF dataset</a> in a <dfn>concrete RDF syntax</dfn>,
@@ -513,7 +513,7 @@
     another specification.</p>
 
   <section id="rdf-strings">
-    <h2>Strings in RDF</h2>
+    <h3>Strings in RDF</h3>
 
     <p>RDF uses Unicode [[Unicode]] as the fundamental representation for string values.
       Within this, and related specifications, the term <dfn id="dfn-rdf-string">string</dfn>,
@@ -669,7 +669,7 @@
   </section>
 
   <section id="section-Graph-Literal">
-    <h2>Literals</h2>
+    <h3>Literals</h3>
 
     <p>Literals are used for values such as strings, numbers, and dates.</p>
 
@@ -797,7 +797,7 @@
   </section>
 
   <section id="section-blank-nodes">
-    <h2>Blank Nodes</h2>
+    <h3>Blank Nodes</h3>
 
     <p><dfn data-lt="blank node">Blank nodes</dfn> are disjoint from
       <a>IRIs</a> and <a>literals</a>.  Otherwise,
@@ -1062,30 +1062,29 @@
       <a>RDF graphs</a>.  If an <a>RDF dataset</a>
       is returned and the consumer is expecting an <a>RDF graph</a>,
       the consumer is expected to use the <a data-lt="rdf dataset">RDF dataset's</a> default graph.</p>
+  </section>
 
-    </section>
+  <section id="section-dataset-quad" class="informative">
+    <h3>Dataset as a Set of Quads</h3>
+    
+    <p>A <dfn>quad</dfn> is a <a>triple</a> associated with an optional <a>graph name</a>
+      and is used when referring to triples within an <a>RDF dataset</a>.
+    </p>
 
-    <section id="section-dataset-quad" class="informative">
-      <h3>Dataset as a Set of Quads</h3>
+    <p>A <a>quad</a> can be represented as a tuple composed of <a>subject</a>, <a>predicate</a>, <a>object</a>,
+      and an optional <a>graph name</a>.</p>
 
-      <p>A <dfn>quad</dfn> is a <a>triple</a> associated with an optional <a>graph name</a>
-        and is used when referring to triples within an <a>RDF dataset</a>.
-      </p>
+    <p>An <a>RDF dataset</a> can be considered to be a set of <a>quads</a>
+      where quads with no <a>graph name</a> supply the <a>triples</a> of the <a>default graph</a>,
+      and quads with the same graph name
+      supply the triples of the <a>named graph</a> with that name.</p>
 
-      <p>A <a>quad</a> can be represented as a tuple composed of <a>subject</a>, <a>predicate</a>, <a>object</a>,
-        and an optional <a>graph name</a>.</p>
-
-      <p>An <a>RDF dataset</a> can be considered to be a set of <a>quads</a>
-        where quads with no <a>graph name</a> supply the <a>triples</a> of the <a>default graph</a>,
-        and quads with the same graph name
-        supply the triples of the <a>named graph</a> with that name.</p>
-
-      <p class="note">Although a <a>quad</a> without a <a>graph name</a>
-        consists of the same three components as a <a>triple</a>,
-        it is a distinct concept,
-        as it specifically captures the notion of a triple within the <a>default graph</a>
-        of an <a>RDF dataset</a>.</p>
-    </section>
+    <p class="note">Although a <a>quad</a> without a <a>graph name</a>
+      consists of the same three components as a <a>triple</a>,
+      it is a distinct concept,
+      as it specifically captures the notion of a triple within the <a>default graph</a>
+      of an <a>RDF dataset</a>.</p>
+  </section>
 </section>
 
 <section id="section-Datatypes">


### PR DESCRIPTION
This closes: GH-110

This PR restructures and reorders content described on #110. It does not make any wording changes.

The commits split out:
* Rename section 1 "Triple Terms and Reification". New section for the definition of triple terms
* Adjusting `<h2>` usage
* Reordering sections 1.3, 1.4, and 1.5  

so that can adjusted separately.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/112.html" title="Last updated on Nov 3, 2024, 11:47 AM UTC (b1dd38b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/112/e24289d...b1dd38b.html" title="Last updated on Nov 3, 2024, 11:47 AM UTC (b1dd38b)">Diff</a>