### PR TITLE
rdf:JSON lexical-to-value updates

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1617,10 +1617,13 @@
             <a data-cite="INFRA#map-entry">Map entries</a> are treated as being unordered.
           </li>
           <li>A <a data-cite="RFC8259#section-5">JSON Array</a> is mapped to a <a data-cite="INFRA#list">list</a>
-            such that this list contains as many elements as the JSON Array
-            and, for every position |i| in the array, the element at the |i|-th
-            position in the list is the value that results from applying this
-            mapping to the |i|-th element of the array.</li>
+            such that this <a data-cite="INFRA#list">list</a> contains as many
+            elements as the <a data-cite="RFC8259#section-5">JSON Array</a> and, for
+            every position |i| in the <a data-cite="RFC8259#section-5">array</a>,
+            the element at the |i|-th position in the
+            <a data-cite="INFRA#list">list</a> is the value that results from
+            applying this mapping to the |i|-th element of the
+            <a data-cite="RFC8259#section-5">array</a>.</li>
           <li>A <a data-cite="RFC8259#section-6">JSON Number</a> is mapped to
             an <a data-cite="XMLSCHEMA11-2#double"><strong>xsd:double</strong></a>
             using a method consistent with <a data-cite="XMLSCHEMA11-2#f-doubleLexmap">doubleLexicalMap</a>.

--- a/spec/index.html
+++ b/spec/index.html
@@ -1609,19 +1609,19 @@
         literal value (<a data-cite="INFRA#boolean">`true`, `false`</a>, and <a data-cite="INFRA#nulls">null</a>).
 
         <ul>
-          <li>A <a href="RFC8259#section-4">JSON Object</a> is mapped to a <a data-cite="INFRA#ordered-map">map</a>
+          <li>A <a data-cite="RFC8259#section-4">JSON Object</a> is mapped to a <a data-cite="INFRA#ordered-map">map</a>
             by transforming each object member into a <a data-cite="INFRA#map-entry">map entry</a>
             with the <a data-cite="INFRA#map-key">key</a> taken from the member name and
             <a data-cite="INFRA#map-value">value</a> taken by performing this mapping
             to the member value.
             <a data-cite="INFRA#map-entry">Map entries</a> are treated as being unordered.
           </li>
-          <li>A <a href="RFC8259#section-5">JSON Array</a> is mapped to a <a data-cite="INFRA#list">list</a>
+          <li>A <a data-cite="RFC8259#section-5">JSON Array</a> is mapped to a <a data-cite="INFRA#list">list</a>
             such that this list contains as many elements as the JSON Array
             and, for every position |i| in the array, the element at the |i|-th
             position in the list is the value that results from applying this
             mapping to the |i|-th element of the array.</li>
-          <li>A <a href="RFC8259#section-6">JSON Number</a> is mapped to
+          <li>A <a data-cite="RFC8259#section-6">JSON Number</a> is mapped to
             an <a data-cite="XMLSCHEMA11-2#double"><strong>xsd:double</strong></a>
             using a method consistent with <a data-cite="XMLSCHEMA11-2#f-doubleLexmap">doubleLexicalMap</a>.
             <div class="note">Some numbers cannot be represented
@@ -1629,10 +1629,10 @@
               and may map to `+INF` or `-INF`.
               Such values cannot be represented as JSON Numbers, limiting the ability to serialize such values back to JSON.</div>
           </li>
-          <li>A <a href="RFC8259#section-7">JSON String</a> is mapped to
+          <li>A <a data-cite="RFC8259#section-7">JSON String</a> is mapped to
             a <a>string</a> after converting any escape sequences to the associated
             <a data-cite="I18N-GLOSSARY#dfn-code-point">Unicode code point</a>.</li>
-          <li>A <a href="RFC8259#section-3">JSON literal name</a> maps
+          <li>A <a data-cite="RFC8259#section-3">JSON literal name</a> maps
             `true` to <a data-cite="INFRA#boolean">`true`</a>,
             `false` to <a data-cite="INFRA#boolean">`false`</a>, and
             `null` to <a data-cite="INFRA#nulls">`null`</a>.</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1617,8 +1617,10 @@
             <a data-cite="INFRA#map-entry">Map entries</a> are treated as being unordered.
           </li>
           <li>A <a href="RFC8259#section-5">JSON Array</a> is mapped to a <a data-cite="INFRA#list">list</a>
-            by performing this mapping on each array value,
-            and adding that mapped value at the same index within the <a data-cite="INFRA#list">list</a>.</li>
+            such that this list contains as many elements as the JSON Array
+            and, for every position |i| in the array, the element at the |i|-th
+            position in the list is the value that results from applying this
+            mapping to the |i|-th element of the array.</li>
           <li>A <a href="RFC8259#section-6">JSON Number</a> is mapped to
             an <a data-cite="XMLSCHEMA11-2#double"><strong>xsd:double</strong></a>
             using a method consistent with <a data-cite="XMLSCHEMA11-2#f-doubleLexmap">doubleLexicalMap</a>.

--- a/spec/index.html
+++ b/spec/index.html
@@ -1636,9 +1636,10 @@
             a <a>string</a> after converting any escape sequences to the associated
             <a data-cite="I18N-GLOSSARY#dfn-code-point">Unicode code point</a>.</li>
           <li>A <a data-cite="RFC8259#section-3">JSON literal name</a> maps
-            `true` to <a data-cite="INFRA#boolean">`true`</a>,
+            JSON `true`, `false`, and `null` values
+            to [[INFRA]] <a data-cite="INFRA#boolean">`true`</a>,
             `false` to <a data-cite="INFRA#boolean">`false`</a>, and
-            `null` to <a data-cite="INFRA#nulls">`null`</a>.</li>
+            `null` to <a data-cite="INFRA#nulls">`null`</a> values, respectively.</li>
         </ul>
       </dd>
     </dl>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1615,9 +1615,10 @@
             <a data-cite="INFRA#map-value">value</a> taken by performing this mapping
             to the member value.
             <a data-cite="INFRA#map-entry">Map entries</a> are treated as being unordered.
-            </li>
+          </li>
           <li>A <a href="RFC8259#section-5">JSON Array</a> is mapped to a <a data-cite="INFRA#list">list</a>
-            by performing this mapping on each array value.</li>
+            by performing this mapping on each array value,
+            and adding that mapped value at the same index within the <a data-cite="INFRA#list">list</a>.</li>
           <li>A <a href="RFC8259#section-6">JSON Number</a> is mapped to
             an <a data-cite="XMLSCHEMA11-2#double"><strong>xsd:double</strong></a>
             using a method consistent with <a data-cite="XMLSCHEMA11-2#f-doubleLexmap">doubleLexicalMap</a>.
@@ -1627,9 +1628,12 @@
               Such values cannot be represented as JSON Numbers, limiting the ability to serialize such values back to JSON.</div>
           </li>
           <li>A <a href="RFC8259#section-7">JSON String</a> is mapped to
-            a <a>string</a>.</li>
-          <li>A <a href="RFC8259#section-3">JSON literal name</a> is mapped to
-            <a data-cite="INFRA#boolean">`true`, `false`</a>, or <a data-cite="INFRA#nulls">null</a>.</li>
+            a <a>string</a> after converting any escape sequences to the associated
+            <a data-cite="I18N-GLOSSARY#dfn-code-point">Unicode code point</a>.</li>
+          <li>A <a href="RFC8259#section-3">JSON literal name</a> maps
+            `true` to <a data-cite="INFRA#boolean">`true`</a>,
+            `false` to <a data-cite="INFRA#boolean">`false`</a>, and
+            `null` to <a data-cite="INFRA#nulls">`null`</a>.</li>
         </ul>
       </dd>
     </dl>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1634,7 +1634,9 @@
             <a data-cite="RFC8259#section-5">array</a>.</li>
           <li>A <a data-cite="RFC8259#section-6">JSON Number</a> is mapped to
             an <a data-cite="XMLSCHEMA11-2#double"><strong>xsd:double</strong></a>
-            using a method consistent with <a data-cite="XMLSCHEMA11-2#f-doubleLexmap">doubleLexicalMap</a>.
+            using a method consistent with <a data-cite="XMLSCHEMA11-2#f-doubleLexmap">doubleLexicalMap</a>,
+            which MUST strictly conform to the rounding method described in
+            <a data-cite="XMLSCHEMA11-2#f-floatPtRound">floatPtRound</a>.
             <div class="note">Some numbers cannot be represented
               as finite <a data-cite="XMLSCHEMA11-2#double"><strong>xsd:double</strong></a> values
               and may map to `+INF` or `-INF`.

--- a/spec/index.html
+++ b/spec/index.html
@@ -1614,7 +1614,7 @@
         number (<a data-cite="XMLSCHEMA11-2#double"><strong>xsd:double</strong></a>),
         <a data-cite="INFRA#ordered-map">map</a>,
         <a data-cite="INFRA#list">list</a>, or
-        literal value (<a data-cite="INFRA#boolean">`true`, `false`</a>, and <a data-cite="INFRA#nulls">null</a>).
+        literal value (<a data-cite="INFRA#boolean">`true`, `false`</a>, and <a data-cite="INFRA#nulls">`null`</a>).
 
         <ul>
           <li>A <a data-cite="RFC8259#section-4">JSON Object</a> is mapped to a <a data-cite="INFRA#ordered-map">map</a>
@@ -1636,7 +1636,7 @@
             an <a data-cite="XMLSCHEMA11-2#double"><strong>xsd:double</strong></a>
             using a method consistent with <a data-cite="XMLSCHEMA11-2#f-doubleLexmap">doubleLexicalMap</a>,
             which MUST strictly conform to the rounding method described in
-            <a data-cite="XMLSCHEMA11-2#f-floatPtRound">floatPtRound</a>.
+            <a data-cite="XMLSCHEMA11-2#f-floatPtRound">floatPtRound</a> [[XMLSCHEMA11-2]].
             <div class="note">Some numbers cannot be represented
               as finite <a data-cite="XMLSCHEMA11-2#double"><strong>xsd:double</strong></a> values
               and may map to `+INF` or `-INF`.
@@ -1648,8 +1648,8 @@
           <li>A <a data-cite="RFC8259#section-3">JSON literal name</a> maps
             JSON `true`, `false`, and `null` values
             to [[INFRA]] <a data-cite="INFRA#boolean">`true`</a>,
-            `false` to <a data-cite="INFRA#boolean">`false`</a>, and
-            `null` to <a data-cite="INFRA#nulls">`null`</a> values, respectively.</li>
+            <a data-cite="INFRA#boolean">`false`</a>, and
+            <a data-cite="INFRA#nulls">`null`</a> values, respectively.</li>
         </ul>
       </dd>
     </dl>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1561,7 +1561,7 @@
         </div></dd>
 
       <dt id="JSON-value-space">The <a>value space</a></dt>
-      <dd>is the set of
+      <dd>is the set the smallest set containing
         <a>strings</a>,
         numbers (<a data-cite="XMLSCHEMA11-2#double"><strong>xsd:double</strong></a>),
         <a data-cite="INFRA#ordered-map">maps</a>
@@ -1570,6 +1570,10 @@
         (of values in the <a href="#JSON-value-space">value space</a>), and
         literal values (<a data-cite="INFRA#boolean">`true`, `false`</a>, and <a data-cite="INFRA#nulls">`null`</a>)
         from [[[INFRA]]] [[INFRA]] and [[[XMLSCHEMA11-2]]] [[XMLSCHEMA11-2]].
+
+        <p class="note">The value space of <a data-cite="INFRA#ordered-map">maps</a>
+          and <a data-cite="INFRA#list">lists</a> does not include values having themselves as members,
+          which cannot be represented in JSON.</p>
 
         <p>Two values (|a| and |b|) are considered equal if any of the following are true:
           <ul>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1586,15 +1586,23 @@
               at the corresponding index in |b|,
               and both |a| and |b| have the same <a data-cite="INFRA#list-size">size</a>.</li>
             <li>They are both <a data-cite="INFRA#ordered-map">maps</a> with equal <a data-cite="INFRA#map-entry">entries</a>
-              – meaning that both |a| and |b| have the same <a data-cite="INFRA#map-size">size</a>,
-              and for each entry <var>e<sub>a</sub></var> in |a|
-              there is an entry <var>e<sub>b</sub></var> in |b|
+              – meaning that for each entry <var>e<sub>a</sub></var> in |a|
+              there exists an entry <var>e<sub>b</sub></var> in |b|
               such that the <a data-cite="INFRA#map-key">key</a> in <var>e<sub>a</sub></var>
               equals the <a data-cite="INFRA#map-key">key</a> in <var>e<sub>b</sub></var>,
-              and the <a data-cite="INFRA#map-value">value</a> in <var>e<sub>a</sub></var>
-              equals the <a data-cite="INFRA#map-value">value</a> in <var>e<sub>b</sub></var>.
+              the <a data-cite="INFRA#map-value">value</a> in <var>e<sub>a</sub></var>
+              equals the <a data-cite="INFRA#map-value">value</a> in <var>e<sub>b</sub></var>,
+              and both |a| and |b| have the same <a data-cite="INFRA#map-size">size</a>.
               <div class="note">Two JSON Objects containing maps which are serialized with entries in a different order will be equal under this definition when transformed to the value space.
               For example, `{ "a": 1, "b": 2 } and { "b": 2, "a": 1 }` are considered equal.
+              As a result of the value space being defined using terminology from [[INFRA]],
+              property values which can contain more than one item, such as <a data-cite="INFRA#list">lists</a> and <a data-cite="INFRA#ordered-map">maps</a>,
+              are explicitly ordered.
+              All list-like value structures in [[INFRA]] are ordered,
+              whether or not that order is significant.
+              For the purposes of this specification, unless otherwise stated,
+              <a data-cite="INFRA#ordered-map">map</a> ordering is not important
+              and implementations are not expected to produce or consume deterministically ordered values.
               </div>
             </li>
           </ul>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1561,7 +1561,7 @@
         </div></dd>
 
       <dt id="JSON-value-space">The <a>value space</a></dt>
-      <dd>is the set the smallest set containing
+      <dd>is the smallest set containing
         <a>strings</a>,
         numbers (<a data-cite="XMLSCHEMA11-2#double"><strong>xsd:double</strong></a>),
         <a data-cite="INFRA#ordered-map">maps</a>


### PR DESCRIPTION
Limit the value space for rdf:JSON to be the "smallest set containing ...". 

Updates rdf:JSON L2V mapping.

Fixes #87.Fixes #88. Fixes #89. Fixes #90. Fixes #91.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/114.html" title="Last updated on Nov 13, 2024, 10:31 PM UTC (1a4984b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/114/e24289d...1a4984b.html" title="Last updated on Nov 13, 2024, 10:31 PM UTC (1a4984b)">Diff</a>