### PR TITLE
Add requirements for the L2V mapping of xsd:float and xsd:double.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1242,6 +1242,12 @@
       <tr><td><a data-cite="xmlschema11-2#NCName"><code>xsd:NCName</code></a></td><td>XML NCNames</td></tr>
     </table>
 
+    <p>The <a>lexical-to-value mapping</a> for <a data-cite="xmlschema11-2#float"><code>xsd:float</code></a>
+      and <a data-cite="xmlschema11-2#double"><code>xsd:double</code></a>
+      MUST use a method consistent with <a data-cite="XMLSCHEMA11-2#f-doubleLexmap">doubleLexicalMap</a>,
+      which MUST strictly conform to the rounding method described in
+      <a data-cite="XMLSCHEMA11-2#f-floatPtRound">floatPtRound</a> [[XMLSCHEMA11-2]].</p>
+
     <p>The other built-in XML Schema datatypes are unsuitable
       for various reasons and SHOULD NOT be used:</p>
 


### PR DESCRIPTION
Fixes #85.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/117.html" title="Last updated on Nov 18, 2024, 7:46 PM UTC (c524161)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/117/8fcd2b7...c524161.html" title="Last updated on Nov 18, 2024, 7:46 PM UTC (c524161)">Diff</a>