### PR TITLE
Datatype are identified by IRIs, not denoted

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1103,7 +1103,7 @@
 
   <p>A <dfn>datatype</dfn> consists of a <a>lexical space</a>,
     a <a>value space</a> and a <a>lexical-to-value mapping</a>, and
-    is denoted by one or more <a>IRIs</a>.</p>
+    is identified by one or more <a>IRIs</a>.</p>
 
   <p>The <dfn>lexical space</dfn> of a datatype is a set of <a>strings</a>.</p>
 


### PR DESCRIPTION
As [pointed out](https://github.com/w3c/rdf-concepts/pull/124/files#r1908630747) by @pchampin the definition of datatype in RDF Concept needs to be aligned with RDF Semantics in terms of how the relationship between a datatype IRI and the corresponding datatype is called.