### PR TITLE
Move note about IRI grammar

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -583,9 +583,6 @@
       is a <a>string</a> that conforms to the syntax
       defined in RFC 3987 [[!RFC3987]].</p>
 
-    <p class="note">For convenience, a complete [[ABNF]] grammar
-      from [[RFC3987]] is provided in <a href="#iri-abnf" class="sectionRef"></a>.</p>
-
     <p>IRIs in the RDF abstract syntax MUST be <a data-cite="RFC3986#section-5">resolved</a>
       per [[RFC3986]],
       and MAY contain a fragment identifier.</p>
@@ -598,6 +595,9 @@
       (This is done in the abstract syntax, so the IRIs are resolved
       IRIs with no escaping or encoding.)
       Further normalization MUST NOT be performed before this comparison. </p>
+
+    <p class="note">For convenience, a complete [[ABNF]] grammar
+      from [[RFC3987]] is provided in <a href="#iri-abnf" class="sectionRef"></a>.</p>
 
     <div class="note" id="note-iris">
       <p><strong>URIs and IRIs:</strong>


### PR DESCRIPTION
Move the NOTE about the grammar to after the "IRI equality" paragraph so the section text is not split.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/131.html" title="Last updated on Jan 16, 2025, 7:09 PM UTC (0a39363)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/131/48e52d2...0a39363.html" title="Last updated on Jan 16, 2025, 7:09 PM UTC (0a39363)">Diff</a>