### PR TITLE
Fixes markup in Sec.3.8 (Graph Comparison)

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -955,20 +955,20 @@
       <a>RDF graphs</a> <var>G</var> and <var>G'</var> are
       <dfn data-lt="graph isomorphism|isomorphic" data-lt-noDefault class="export">isomorphic</dfn>
       (that is, they have an identical form)
-      if there is a bijection <var>M</var> between the sets of nodes of the two
+      if there is a bijection <var>M</var> between the sets of <a>nodes</a> of the two
       graphs, such that all of the following properties hold:</p>
 
     <ul>
       <li><var>M</var> maps blank nodes to blank nodes.</li>
-      <li><var>M(lit)=lit</var> for all <a>RDF literals</a> <var>lit</var> which
-        are nodes of <var>G</var>.</li>
+      <li><var>M</var>(<var>lit</var>)=<var>lit</var> for every <a>RDF literal</a> <var>lit</var> that
+        is a node of <var>G</var>.</li>
 
-      <li><var>M(iri)=iri</var> for all <a>IRIs</a> <var>iri</var>
-        which are nodes of <var>G</var>.</li>
+      <li><var>M</var>(<var>iri</var>)=<var>iri</var> for every <a>IRI</a> <var>iri</var>
+        that is a node of <var>G</var>.</li>
 
-      <li>The triple <var>( s, p, o )</var> is in <var>G</var> if and
-        only if the triple <var>( M(s), p, M(o) )</var> is in
-        <var>G'</var></li>
+      <li>The triple ( <var>s</var>, <var>p</var>, <var>o</var> ) is in <var>G</var> if and
+        only if the triple ( <var>M</var>(<var>s</var>), <var>p</var>, <var>M</var>(<var>o</var>) ) is in
+        <var>G'</var>.</li>
     </ul>
 
     <p>See also: <a>IRI equality</a>, <a>literal term equality</a>.</p>


### PR DESCRIPTION
In preparation for working on #128, this PR fixes the markup within Sec.3.8. In particular, `<var>` has been used incorrectly. For instance, _M(lit)=lit_ is not a variable but a formula; the variables in this formula are _M_ and _lit_.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/137.html" title="Last updated on Jan 17, 2025, 10:47 AM UTC (f40bf54)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/137/48e52d2...f40bf54.html" title="Last updated on Jan 17, 2025, 10:47 AM UTC (f40bf54)">Diff</a>