### PR TITLE
Updates the definition of graph isomorphism

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -961,11 +961,9 @@
 
     <ul>
       <li><var>M</var> maps blank nodes to blank nodes.</li>
-      <li><var>M</var>(<var>lit</var>)=<var>lit</var> for every <a>RDF literal</a> <var>lit</var> that
-        is a node of <var>G</var>.</li>
+      <li><var>M</var>(<var>lit</var>)=<var>lit</var> for every <a>RDF literal</a> <var>lit</var>.</li>
 
-      <li><var>M</var>(<var>iri</var>)=<var>iri</var> for every <a>IRI</a> <var>iri</var>
-        that is a node of <var>G</var>.</li>
+      <li><var>M</var>(<var>iri</var>)=<var>iri</var> for every <a>IRI</a> <var>iri</var>.</li>
 
       <li><var>M</var>(<var>tt</var>) is the triple term ( <var>M</var>(<var>s</var>), <var>M</var>(<var>p</var>), <var>M</var>(<var>o</var>) ) if <var>tt</var> is a triple term of the form ( <var>s</var>, <var>p</var>, <var>o</var> ).</li>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -955,8 +955,9 @@
       <a>RDF graphs</a> <var>G</var> and <var>G'</var> are
       <dfn data-lt="graph isomorphism|isomorphic" data-lt-noDefault class="export">isomorphic</dfn>
       (that is, they have an identical form)
-      if there is a bijection <var>M</var> between the sets of <a>nodes</a> of the two
-      graphs, such that all of the following properties hold:</p>
+      if there is a bijection <var>M</var>
+      from the set of all <a>RDF terms</a> into that same set,
+      such that all of the following properties hold:</p>
 
     <ul>
       <li><var>M</var> maps blank nodes to blank nodes.</li>
@@ -966,8 +967,10 @@
       <li><var>M</var>(<var>iri</var>)=<var>iri</var> for every <a>IRI</a> <var>iri</var>
         that is a node of <var>G</var>.</li>
 
+      <li><var>M</var>(<var>tt</var>) is the triple term ( <var>M</var>(<var>s</var>), <var>M</var>(<var>p</var>), <var>M</var>(<var>o</var>) ) if <var>tt</var> is a triple term of the form ( <var>s</var>, <var>p</var>, <var>o</var> ).</li>
+
       <li>The triple ( <var>s</var>, <var>p</var>, <var>o</var> ) is in <var>G</var> if and
-        only if the triple ( <var>M</var>(<var>s</var>), <var>p</var>, <var>M</var>(<var>o</var>) ) is in
+        only if the triple ( <var>M</var>(<var>s</var>), <var>M</var>(<var>p</var>), <var>M</var>(<var>o</var>) ) is in
         <var>G'</var>.</li>
     </ul>
 


### PR DESCRIPTION
.. as proposed in #128, including the additional change proposed in https://github.com/w3c/rdf-concepts/issues/128#issuecomment-2598233599

Notice that I also removed the "that is a node of G" part of bullet point 2 and 3. This change is needed for the new recursive part of the definition to be correct (i.e., when applying _M_ to IRIs or literals inside triple terms).

Additionally, I also changed the last (now fifth) bullet point by putting _M_(_p_) in the second triple mentioned in this bullet point. While this change is not strictly necessary (because _p_ is an IRI and _M_ maps each IRI to itself), using _M_ here looks a bit more consistent.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/140.html" title="Last updated on Jan 17, 2025, 4:28 PM UTC (b906255)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/140/4d1cc8c...b906255.html" title="Last updated on Jan 17, 2025, 4:28 PM UTC (b906255)">Diff</a>