### PR TITLE
Accept unknown datatypes

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -764,7 +764,9 @@
       </li>
       <li>If the literal's <a>datatype IRI</a> is <em>not</em>
         handled by an RDF implementation, then the literal value is
-        not defined by this specification.</li>
+        not defined by this specification. Implementations SHOULD accept
+        literals with unknown datatype IRIs and produce RDF graphs from them.
+      </li>
     </ul>
 
     <p><dfn data-local-lt="term-equal">Literal term equality</dfn>:

--- a/spec/index.html
+++ b/spec/index.html
@@ -1329,8 +1329,8 @@
       Any literal typed with a datatype not handled by an RDF implementation
       is treated just like an unknown IRI, i.e., as referring to an unknown thing.
       Applications MAY give a warning message if they are unable to determine the
-      referent of an IRI used in a typed literal. RDF implementations SHOULD
-      not reject a literal with an unknown datatype as either a syntactic or
+      referent of an IRI used in a typed literal. RDF implementations SHOULD NOT
+      reject a literal with an unknown datatype as either a syntactic or
       semantic error.<p>
 
     <p>Other specifications MAY impose additional constraints on


### PR DESCRIPTION
NB. This sentence is a reflection of the existing text in [5.2. Datatype IRIs](https://www.w3.org/TR/rdf12-concepts/#datatype-iris), which is also in RDF 1.1.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/141.html" title="Last updated on Jan 19, 2025, 8:11 PM UTC (f12d412)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/141/66d40f5...f12d412.html" title="Last updated on Jan 19, 2025, 8:11 PM UTC (f12d412)">Diff</a>