### PR TITLE
Fix link to RDF Semantics #dfn-recognize

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1346,7 +1346,7 @@
     <p class="note" id="note-recognized-datatype-iris">
       In RDF 1.1, <em><span id="dfn-recognized-datatype-iris">Recognized datatype IRIs</span></em>
       were defined in RDF Concepts, overlapping with 
-      <a data-cite="RDF12-SEMANTICS#dfn-recognized">RDF Semantics, "recognizing"</a>
+      <a data-cite="RDF12-SEMANTICS#dfn-recognize">RDF Semantics, "recognizing"</a>
       datatype IRIs for <a data-cite="RDF12-SEMANTICS#dfn-semantic-extension">semantic extensions</a>.
     </p>
 
@@ -1973,7 +1973,7 @@
       or do something else, as long it is performed consistently.</li>
     <li>Removed the section on the canonical mapping for the <a>rdf:XMLLiteral</a> datatype.</li>
     <li>Refer to the definition and discussion of 
-      <a data-cite="RDF12-SEMANTICS#dfn-recognized">RDF Semantics, "recognizing"</a>
+      <a data-cite="RDF12-SEMANTICS#dfn-recognize">RDF Semantics, "recognizing"</a>
       datatype IRIs, instead of <em>Recognized datatype IRIs</em>.</li>
     <li>The informal terminolgy "RDF processor" has been removed.</li>
   </ul>


### PR DESCRIPTION
This closes #148.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/149.html" title="Last updated on Jan 23, 2025, 3:55 PM UTC (bc1064a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/149/23dfb05...bc1064a.html" title="Last updated on Jan 23, 2025, 3:55 PM UTC (bc1064a)">Diff</a>