### PR TITLE
update RDF dataset discussion with explicit comparison of `{ RDF | SPARQL } { 1.2 | 1.1 | 1.0 }`

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1021,11 +1021,13 @@
       can avoid interoperability issues by not ascribing importance to
       the presence or absence of empty named graphs.</p>
 
-    <p>SPARQL 1.2 [[SPARQL12-QUERY]] uses 
+    <p>Version 1.2 of the SPARQL Query Language [[SPARQL12-QUERY]] uses 
       <a data-cite="SPARQL12-QUERY#sparqlDataset">the same concept of an RDF Dataset</a>
+      as RDF versions 1.1 and 1.2,
       in which the graph names of named graphs may be IRIs or blank nodes.
       In contrast, version 1.1 of the SPARQL Query Language [[SPARQL11-QUERY]]
-      only allows IRIs as graph names.</p>
+      and RDF version 1.0
+      only allowed graph names to be IRIs.</p>
 
   </div>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -1026,7 +1026,6 @@
       as RDF versions 1.1 and 1.2,
       in which the graph names of named graphs may be IRIs or blank nodes.
       In contrast, version 1.1 of the SPARQL Query Language [[SPARQL11-QUERY]]
-      and RDF version 1.0
       only allowed graph names to be IRIs.</p>
 
   </div>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1021,7 +1021,7 @@
       can avoid interoperability issues by not ascribing importance to
       the presence or absence of empty named graphs.</p>
 
-    <p>Version 1.2 of the SPARQL Query Language [[SPARQL12-QUERY]] uses 
+    <p>SPARQL version 1.2 [[SPARQL12-CONCEPTS]] uses 
       <a data-cite="SPARQL12-QUERY#sparqlDataset">the same concept of an RDF Dataset</a>
       as RDF versions 1.1 and 1.2,
       in which the graph names of named graphs may be IRIs or blank nodes.


### PR DESCRIPTION
Add explicit comparison of SPARQL 1.2 and RDF 1.2, vs SPARQL 1.1, RDF 1.1, and RDF 1.0. Might also want specific difference with SPARQL 1.0.

This specificity may not be needed for users who have never before encountered RDF or SPARQL, but I think it helpful for users who *have* worked with any previous version(s) — like me.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TallTed/rdf-concepts/pull/151.html" title="Last updated on Mar 3, 2025, 8:47 PM UTC (4e40fdd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/151/f231b67...TallTed:4e40fdd.html" title="Last updated on Mar 3, 2025, 8:47 PM UTC (4e40fdd)">Diff</a>