### PR TITLE
Definition: ill-typed

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -765,12 +765,12 @@
             of the <a>datatype</a>, then the literal value is the result of applying
             the <a>lexical-to-value mapping</a> of the datatype to the
             <a>lexical form</a>.</li>
-          <li>otherwise, the literal is ill-typed and no literal value can be
+          <li>otherwise, the literal is <dfn data-lt-no-plural>ill-typed</dfn> and no literal value can be
              associated with the literal. Such a case produces a semantic
              inconsistency but is not <em>syntactically</em> ill-formed.
-             Implementations SHOULD accept ill-typed literals and produce RDF
+             Implementations SHOULD accept [=ill-typed=] literals and produce RDF
              graphs from them. Implementations MAY produce warnings when
-             encountering ill-typed literals.</li>
+             encountering [=ill-typed=] literals.</li>
         </ul>
       </li>
       <li>If the literal's <a>datatype IRI</a> is <em>not</em>


### PR DESCRIPTION
"ill-typed" is core terminology that can be used in other documents.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/153.html" title="Last updated on Jan 31, 2025, 3:19 PM UTC (9181ee1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/153/211bafc...9181ee1.html" title="Last updated on Jan 31, 2025, 3:19 PM UTC (9181ee1)">Diff</a>