### PR TITLE
IRIs are equal

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -656,7 +656,7 @@
     </p>
 
     <p><dfn>IRI equality</dfn>:
-      Two IRIs are the same if and only if they consist of the same sequence of
+      Two IRIs are equal if and only if they consist of the same sequence of
       <a data-cite="I18N-GLOSSARY#dfn-code-point" class="lint-ignore">Unicode code points</a>,
       as in Simple String Comparison in
       <a data-cite="rfc3987#section-5.3.1">section 5.3.1</a> of [[!RFC3987]].


### PR DESCRIPTION
Triples/triple terms, literals and blank nodes use "equal" but IRI equality (section title) uses the word "same". 

"same" risks being read as "de-references to same web resource".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/165.html" title="Last updated on Mar 9, 2025, 9:26 AM UTC (0088f4a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/165/2146f1c...0088f4a.html" title="Last updated on Mar 9, 2025, 9:26 AM UTC (0088f4a)">Diff</a>