### PR TITLE
Clarification of the points of 'literal term equality'

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -799,7 +799,7 @@
       <li>The two <a>language tags</a> are either both absent, or both present and compare equal,
         where this comparison is performed using
         <a data-cite="I18N-GLOSSARY#dfn-case-sensitive">ASCII case-insensitive matching</a>
-        (i.e., in contrast to the case-sensitive comparison of the lexical forms).</li>
+        (in contrast to the case-sensitive comparison of the lexical forms).</li>
       <li>The two <a>base directions</a> are either both absent, both `ltr`, or both `rtl`.</li>
     </ul>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -798,7 +798,7 @@
         (per [=IRI equality=]).</li>
       <li>The two <a>language tags</a> are either both absent, or both present and compare equal,
         where this comparison is performed using
-        <a data-cite="I18N-GLOSSARY#dfn-case-sensitive">ASCII case-insensitive matching</a>
+        <a data-cite="I18N-GLOSSARY##dfn-ascii-case-insensitive">ASCII case-insensitive matching</a>
         (in contrast to the case-sensitive comparison of the lexical forms).</li>
       <li>The two <a>base directions</a> are either both absent, both `ltr`, or both `rtl`.</li>
     </ul>

--- a/spec/index.html
+++ b/spec/index.html
@@ -798,7 +798,7 @@
         (per [=IRI equality=]).</li>
       <li>The two <a>language tags</a> are either both absent, or both present and compare equal,
         where this comparison is performed using
-        <a data-cite="I18N-GLOSSARY##dfn-ascii-case-insensitive">ASCII case-insensitive matching</a>
+        <a data-cite="I18N-GLOSSARY#dfn-ascii-case-insensitive">ASCII case-insensitive matching</a>
         (in contrast to the case-sensitive comparison of the lexical forms).</li>
       <li>The two <a>base directions</a> are either both absent, both `ltr`, or both `rtl`.</li>
     </ul>

--- a/spec/index.html
+++ b/spec/index.html
@@ -789,18 +789,19 @@
       if and only if the following are all true:</p>
 
     <ul>
-      <li>The two <a>lexical forms</a> compare equal.</li>
-      <li>The two <a>datatype IRIs</a> compare equal.</li>
-      <li>The two <a>language tags</a> are either both absent, or both present and compare equal.</li>
+      <li>The two <a>lexical forms</a> compare equal,
+        where this comparison is performed using
+        <a data-cite="I18N-GLOSSARY#dfn-case-sensitive">case-sensitive matching</a>
+        (see description of string comparison in
+        <a href="#rdf-strings" class="sectionRef"></a>).</li>
+      <li>The two <a>datatype IRIs</a> compare [=IRI equality|equal=]
+        (per [=IRI equality=]).</li>
+      <li>The two <a>language tags</a> are either both absent, or both present and compare equal,
+        where this comparison is performed using
+        <a data-cite="I18N-GLOSSARY#dfn-case-sensitive">ASCII case-insensitive matching</a>
+        (i.e., in contrast to the case-sensitive comparison of the lexical forms).</li>
       <li>The two <a>base directions</a> are either both absent, both `ltr`, or both `rtl`.</li>
     </ul>
-    <p>Comparison of the [=lexical forms=] and of the [=datatype IRIs=] is performed using
-      <a data-cite="I18N-GLOSSARY#dfn-case-sensitive">case sensitive matching</a>
-      (see description of string comparison in
-      <a href="#rdf-strings" class="sectionRef"></a>).
-      Comparison of the [=language tags=] is performed using
-      <a data-cite="I18N-GLOSSARY#dfn-case-sensitive">ASCII case-insensitive matching</a>.
-    </p>
 
     <section>
       <h2>Representation of literals</h2>


### PR DESCRIPTION
This PR is a follow-up to PR #162, in particular to [my comment](https://github.com/w3c/rdf-concepts/pull/162#discussion_r1971936038) that the definition of [literal term equality](https://w3c.github.io/rdf-concepts/spec/#dfn-literal-term-equality) should mention [IRI equality](https://w3c.github.io/rdf-concepts/spec/#dfn-iri-equality) for the datatype IRI. This PR implements this proposal and, additionally, extends the four points of the definition of [literal term equality](https://w3c.github.io/rdf-concepts/spec/#dfn-literal-term-equality) with the corresponding part of the paragraph about how the respective comparison should be performed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/167.html" title="Last updated on Mar 20, 2025, 7:37 PM UTC (20d722b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/167/0301846...20d722b.html" title="Last updated on Mar 20, 2025, 7:37 PM UTC (20d722b)">Diff</a>