### PR TITLE
Update figure style of triple terms

### DIFF
--- a/spec/asserted-triple-term.svg
+++ b/spec/asserted-triple-term.svg
@@ -1,18 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0.0 0.0 464 324">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0.0 0.0 464 324">
 
-  <style>
-    :root { --bg: #fff; --solid: #eee; --mid: #aaa; --fg: #000 }
-    @media (prefers-color-scheme: dark) {
-      :root { --bg: #000; --solid: #333; --mid: #777; --fg: #eee }
-    }
-    svg { background-color: var(--bg); stroke: none; }
-    ellipse { stroke: var(--fg); fill: var(--solid) }
-    path.arrow { stroke: var(--fg); marker-end: url(#arrowhead) }
-    text { fill: var(--fg); font-family: Helvetica, sans-serif; }
-    text.middle { text-anchor: middle }
-    text.italic { font-style: italic }
-    path.reifies { stroke: var(--fg); stroke-width: 1; marker-start: url(#arrowhead); fill: none }
-  </style>
+  <style>@import url('figure.css')</style>
 
   <defs>
     <marker id="arrowhead" orient="auto-start-reverse" markerWidth="10" markerHeight="10"

--- a/spec/asserted-triple-term.svg
+++ b/spec/asserted-triple-term.svg
@@ -1,53 +1,59 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0.0 0.0 464 296">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0.0 0.0 464 324">
 
   <style>
-      svg { fill: none; stroke: none; }
-      ellipse { stroke: #000 }
-      path.arrow { stroke: #000; marker-end: url(#arrowhead) }
-      text { fill: #000; font-family: Helvetica, sans-serif; }
-      text.middle { text-anchor: middle }
-      text.italic { font-style: italic }
-      .rei { fill: #fff }
-      rect.quoted { fill: #ccc; stroke: #000; }
-      rect.reifies { fill: #fff; stroke: #000; }
+    :root { --bg: #fff; --solid: #eee; --mid: #aaa; --fg: #000 }
+    @media (prefers-color-scheme: dark) {
+      :root { --bg: #000; --solid: #333; --mid: #777; --fg: #eee }
+    }
+    svg { background-color: var(--bg); stroke: none; }
+    ellipse { stroke: var(--fg); fill: var(--solid) }
+    path.arrow { stroke: var(--fg); marker-end: url(#arrowhead) }
+    text { fill: var(--fg); font-family: Helvetica, sans-serif; }
+    text.middle { text-anchor: middle }
+    text.italic { font-style: italic }
+    path.reifies { stroke: var(--fg); stroke-width: 1; marker-start: url(#arrowhead); fill: none }
   </style>
 
   <defs>
-    <marker id="arrowhead" orient="auto" markerWidth="8" markerHeight="8"
-            refX="0" refY="3">
-      <path d="M0,0 V6 L8,3 Z" fill="#000" />
+    <marker id="arrowhead" orient="auto-start-reverse" markerWidth="10" markerHeight="10"
+            refX="0" refY="5">
+      <path d="M0,0 V10 L10,5 Z" fill="context-stroke" />
     </marker>
   </defs>
 
-  <g transform="translate(230, 256)">
-    <ellipse rx="80" ry="36"/>
-    <text class="middle" y="6">:Bob</text>
-  </g>
-  <rect class="reifies" x="5" y="2" width="453" height="128" rx="16"/>
-
-  <g transform="translate(230, 128)">
-    <ellipse class="rei" rx="60" ry="24"/>
-    <text class="middle italic" y="6">_:rei-1</text>
-    <text class="italic" x="72" y="-6">rdf:reifies</text>
-  </g>
-  <g transform="translate(230, 68)">
-    <path d="M0,84 0,142" class="arrow"/>
-    <text x="8" y="118">:accordingTo</text>
-  </g>
-
-  <g transform="translate(0, 58)">
+  <g transform="translate(0, 48)">
     <g transform="translate(100, 0)">
       <ellipse rx="80" ry="36"/>
       <text class="middle" y="6">:Alice</text>
     </g>
     <g transform="translate(180, 2)">
-      <path d="M0,0 95,0" class="arrow"/>
+      <path d="M0,0 92,0" class="arrow"/>
       <text x="26" y="-8">:name</text>
     </g>
     <g transform="translate(363, 0)">
       <ellipse rx="80" ry="36"/>
       <text class="middle" y="6">"Alice"</text>
     </g>
+  </g>
+
+  <g transform="translate(230, 60)">
+    <path d="m 0,1 c -8,16 -16,24 0,34 s 0,24 0,37" class="reifies"/>
+    <text class="italic" dx="16" dy="50">rdf:reifies</text>
+  </g>
+
+  <g transform="translate(228, 150)">
+    <ellipse rx="48" ry="18"/>
+    <text class="middle italic" y="6">:rei-1</text>
+  </g>
+
+  <g transform="translate(230, 84)">
+    <path d="M0,84 0,140" class="arrow"/>
+    <text x="8" y="118">:accordingTo</text>
+  </g>
+
+  <g transform="translate(230, 272)">
+    <ellipse rx="80" ry="36"/>
+    <text class="middle" y="6">:Bob</text>
   </g>
 
 </svg>

--- a/spec/figure.css
+++ b/spec/figure.css
@@ -1,0 +1,16 @@
+:root { --bg: #fff; --solid: #eee; --abstract: #aaa; --fg: #000 }
+@media (prefers-color-scheme: dark) {
+  :root { --bg: #000; --solid: #333; --abstract: #777; --fg: #eee }
+}
+svg { background-color: var(--bg); stroke: none }
+ellipse { stroke: var(--fg); fill: var(--solid) }
+path.arrow { stroke: var(--fg); marker-end: url(#arrowhead) }
+#arrowhead { fill: var(--fg) }
+text { fill: var(--fg); font-family: Helvetica, sans-serif }
+text.middle { text-anchor: middle }
+text.italic { font-style: italic }
+path.reifies { stroke: var(--fg); stroke-width: 1; marker-start: url(#arrowhead); fill: none }
+.abstract > path.arrow { stroke: var(--abstract); stroke-dasharray: 8; marker-end: url(#arrowhead-abstract) }
+#arrowhead-abstract { fill: var(--abstract) }
+.abstract > text { fill: var(--abstract) }
+.unlinked > ellipse { stroke: var(--abstract) }

--- a/spec/index.html
+++ b/spec/index.html
@@ -333,32 +333,34 @@
       Concrete syntaxes, such as Turtle [[RDF12-TURTLE]],
       may have shortcuts for capturing a <a>triple term</a> with its <a>reifier</a>.</p>
 
-    <p>The following diagram represents a statement and a reification of an unasserted <a>triple term</a>.</p>
+    <p>The following diagram represents a <a>reifying triple</a> of an unasserted, abstract <a>triple term</a>, and a <a>triple</a> relating the <a>reifier</a> to another resource.</p>
 
     <figure id="fig-triple-term">
       <a href="triple-term.svg">
         <!-- A version of this graphic can be found at https://docs.google.com/drawings/d/1RP9Nw5GCNjduWSXZj_EZ8FaAc7p_N-WVmzJ0syvum1k -->
         <img src="triple-term.svg"
-             alt="An RDF graph containing a triple that references an unasserted triple term (with grey background) via a reifier"
+             alt="An RDF graph containing a triple that references an unasserted triple term (with grey dashed arc) via a reifier"
              aria-describedby="fig-triple-term-alt"/>
       </a>
       <figcaption id="fig-triple-term-alt">
-        An <a>RDF graph</a> containing a <a>triple</a> that references an unasserted <a>triple term</a> (with grey background) via a <a>reifier</a>.
+        An <a>RDF graph</a> containing a <a>reifying triple</a> that references an abstract <a>triple term</a> (which is unasserted, depicted using a grey, dashed arc) from a <a>reifier</a>; and a triple describing this reifier.
       </figcaption>
     </figure>
 
-    <p>A variation on the graph shown in <a href="#fig-triple-term"></a> can be described
-      where the <a>triple term</a> is also <a data-lt="asserted triple">asserted</a>.</p>
+    <p>Here is a variation on the graph shown in <a href="#fig-triple-term"></a>. This represents a graph
+      where the <a>triple term</a> corresponds to an <a>asserted triple</a>.
+    </p>
 
     <figure id="fig-asserted-triple-term">
       <a href="asserted-triple-term.svg">
         <!-- A version of this graphic can be found at https://docs.google.com/drawings/d/1gAHQj4wk87tmeHf4-wnxdgmjq3T05_ovrJq0V-1VXKw -->
         <img src="asserted-triple-term.svg"
-             alt="An RDF graph containing a triple that references an triple term, which is also asserted, via a reifier"
+             alt="An RDF graph containing a reifying triple where the triple term corresponds to an asserted triple"
              aria-describedby="fig-asserted-triple-term-alt"/>
       </a>
       <figcaption id="fig-asserted-triple-term-alt">
-        An <a>RDF graph</a> containing a <a>triple</a> that references an <a>triple term</a>, which is also asserted, via a <a>reifier</a>.
+        An <a>RDF graph</a> containing a <a>reifying triple</a> where the <a>triple term</a> corresponds to an <a>asserted triple</a>.
+        The diagram represents the proposition as a fact using the asserted triple, meaning that the relationship holds.
       </figcaption>
     </figure>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -44,8 +44,8 @@
     };
   </script>
   <style>
-    body { color-scheme: light }
-    body.darkmode { color-scheme: dark }
+    body:has(input[type='radio'][value='light']:checked) { color-scheme: light }
+    body:has(input[type='radio'][value='dark']:checked) { color-scheme: dark }
     figure { text-align: center; }
     figure img { width: 70%; }
     table.simple td, table th { border: 1px solid #ddd; padding: 0.2em 0.5em; }

--- a/spec/index.html
+++ b/spec/index.html
@@ -337,7 +337,6 @@
 
     <figure id="fig-triple-term">
       <a href="triple-term.svg">
-        <!-- A version of this graphic can be found at https://docs.google.com/drawings/d/1RP9Nw5GCNjduWSXZj_EZ8FaAc7p_N-WVmzJ0syvum1k -->
         <img src="triple-term.svg"
              alt="An RDF graph containing a triple that references an unasserted triple term (with grey dashed arc) via a reifier"
              aria-describedby="fig-triple-term-alt"/>
@@ -353,7 +352,6 @@
 
     <figure id="fig-asserted-triple-term">
       <a href="asserted-triple-term.svg">
-        <!-- A version of this graphic can be found at https://docs.google.com/drawings/d/1gAHQj4wk87tmeHf4-wnxdgmjq3T05_ovrJq0V-1VXKw -->
         <img src="asserted-triple-term.svg"
              alt="An RDF graph containing a reifying triple where the triple term corresponds to an asserted triple"
              aria-describedby="fig-asserted-triple-term-alt"/>

--- a/spec/index.html
+++ b/spec/index.html
@@ -145,7 +145,7 @@
     <figure id="fig-rdf-graph">
       <a href="rdf-graph.svg">
         <object data="rdf-graph.svg"
-          >An RDF graph with two nodes (Subject and Object) and a triple connecting them (Predicate)</object>
+          aria-label="An RDF graph with two nodes (Subject and Object) and a triple connecting them (Predicate)"></object>
       </a>
       <figcaption>An RDF graph with two nodes (Subject and Object) and a triple connecting them (Predicate)</figcaption>
     </figure>
@@ -339,7 +339,7 @@
     <figure id="fig-triple-term">
       <a href="triple-term.svg">
         <object data="triple-term.svg" aria-describedby="fig-triple-term-alt"
-          >An RDF graph containing a triple that references an unasserted triple term (with grey dashed arc) via a reifier</object>
+          aria-label="An RDF graph containing a triple that references an unasserted triple term (with grey dashed arc) via a reifier"></object>
       </a>
       <figcaption id="fig-triple-term-alt">
         An <a>RDF graph</a> containing a <a>reifying triple</a> that references an abstract <a>triple term</a> (which is unasserted, depicted using a grey, dashed arc) from a <a>reifier</a>; and a triple describing this reifier.
@@ -353,7 +353,7 @@
     <figure id="fig-asserted-triple-term">
       <a href="asserted-triple-term.svg">
         <object data="asserted-triple-term.svg" aria-describedby="fig-asserted-triple-term-alt"
-          >An RDF graph containing a reifying triple where the triple term corresponds to an asserted triple</object>
+          aria-label="An RDF graph containing a reifying triple where the triple term corresponds to an asserted triple"></object>
       </a>
       <figcaption id="fig-asserted-triple-term-alt">
         An <a>RDF graph</a> containing a <a>reifying triple</a> where the <a>triple term</a> corresponds to an <a>asserted triple</a>.

--- a/spec/index.html
+++ b/spec/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta name="color-scheme" content="light dark">
   <title>RDF 1.2 Concepts and Abstract Syntax</title>
   <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
   <script src="./common/local-biblio.js" class="remove"></script>
@@ -43,7 +44,10 @@
     };
   </script>
   <style>
+    body { color-scheme: light }
+    body.darkmode { color-scheme: dark }
     figure { text-align: center; }
+    figure img { width: 70%; }
     table.simple td, table th { border: 1px solid #ddd; padding: 0.2em 0.5em; }
     ol ol { list-style-type: lower-latin; }
     .grammar td { font-family: monospace;}
@@ -138,7 +142,10 @@
       node-arc-node link.</p>
 
     <figure id="fig-rdf-graph">
-      <a href="rdf-graph.svg"><img src="rdf-graph.svg" alt="An RDF graph with two nodes (Subject and Object) and a triple connecting them (Predicate)" /></a>
+      <a href="rdf-graph.svg">
+        <img src="rdf-graph.svg"
+             alt="An RDF graph with two nodes (Subject and Object) and a triple connecting them (Predicate)" />
+      </a>
       <figcaption>An RDF graph with two nodes (Subject and Object) and a triple connecting them (Predicate)</figcaption>
     </figure>
 
@@ -333,7 +340,6 @@
         <!-- A version of this graphic can be found at https://docs.google.com/drawings/d/1RP9Nw5GCNjduWSXZj_EZ8FaAc7p_N-WVmzJ0syvum1k -->
         <img src="triple-term.svg"
              alt="An RDF graph containing a triple that references an unasserted triple term (with grey background) via a reifier"
-             style="width:70%"
              aria-describedby="fig-triple-term-alt"/>
       </a>
       <figcaption id="fig-triple-term-alt">
@@ -349,7 +355,6 @@
         <!-- A version of this graphic can be found at https://docs.google.com/drawings/d/1gAHQj4wk87tmeHf4-wnxdgmjq3T05_ovrJq0V-1VXKw -->
         <img src="asserted-triple-term.svg"
              alt="An RDF graph containing a triple that references an triple term, which is also asserted, via a reifier"
-             style="width:70%"
              aria-describedby="fig-asserted-triple-term-alt"/>
       </a>
       <figcaption id="fig-asserted-triple-term-alt">

--- a/spec/index.html
+++ b/spec/index.html
@@ -46,8 +46,9 @@
   <style>
     body:has(input[type='radio'][value='light']:checked) { color-scheme: light }
     body:has(input[type='radio'][value='dark']:checked) { color-scheme: dark }
-    figure { text-align: center; }
-    figure img { width: 70%; }
+    figure { text-align: center }
+    figure > a { display: block }
+    figure > a > object { max-width: 40em; pointer-events: none }
     table.simple td, table th { border: 1px solid #ddd; padding: 0.2em 0.5em; }
     ol ol { list-style-type: lower-latin; }
     .grammar td { font-family: monospace;}
@@ -143,8 +144,8 @@
 
     <figure id="fig-rdf-graph">
       <a href="rdf-graph.svg">
-        <img src="rdf-graph.svg"
-             alt="An RDF graph with two nodes (Subject and Object) and a triple connecting them (Predicate)" />
+        <object data="rdf-graph.svg"
+          >An RDF graph with two nodes (Subject and Object) and a triple connecting them (Predicate)</object>
       </a>
       <figcaption>An RDF graph with two nodes (Subject and Object) and a triple connecting them (Predicate)</figcaption>
     </figure>
@@ -337,9 +338,8 @@
 
     <figure id="fig-triple-term">
       <a href="triple-term.svg">
-        <img src="triple-term.svg"
-             alt="An RDF graph containing a triple that references an unasserted triple term (with grey dashed arc) via a reifier"
-             aria-describedby="fig-triple-term-alt"/>
+        <object data="triple-term.svg" aria-describedby="fig-triple-term-alt"
+          >An RDF graph containing a triple that references an unasserted triple term (with grey dashed arc) via a reifier</object>
       </a>
       <figcaption id="fig-triple-term-alt">
         An <a>RDF graph</a> containing a <a>reifying triple</a> that references an abstract <a>triple term</a> (which is unasserted, depicted using a grey, dashed arc) from a <a>reifier</a>; and a triple describing this reifier.
@@ -352,9 +352,8 @@
 
     <figure id="fig-asserted-triple-term">
       <a href="asserted-triple-term.svg">
-        <img src="asserted-triple-term.svg"
-             alt="An RDF graph containing a reifying triple where the triple term corresponds to an asserted triple"
-             aria-describedby="fig-asserted-triple-term-alt"/>
+        <object data="asserted-triple-term.svg" aria-describedby="fig-asserted-triple-term-alt"
+          >An RDF graph containing a reifying triple where the triple term corresponds to an asserted triple</object>
       </a>
       <figcaption id="fig-asserted-triple-term-alt">
         An <a>RDF graph</a> containing a <a>reifying triple</a> where the <a>triple term</a> corresponds to an <a>asserted triple</a>.

--- a/spec/rdf-graph.svg
+++ b/spec/rdf-graph.svg
@@ -1,15 +1,6 @@
-<svg viewBox="0 0 464 80" xmlns="http://www.w3.org/2000/svg">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 464 80">
 
-  <style type="text/css">
-    :root { --bg: #fff; --solid: #eee; --mid: #aaa; --fg: #000 }
-    @media (prefers-color-scheme: dark) {
-      :root { --bg: #000; --solid: #333; --mid: #777; --fg: #eee }
-    }
-    svg { background-color: var(--bg); stroke: none; }
-    ellipse { stroke: var(--fg); fill: var(--solid) }
-    path.arrow { stroke: var(--fg); marker-end: url(#arrowhead) }
-    text { fill: var(--fg); text-anchor: middle; font-family: Helvetica, sans-serif; }
-  </style>
+  <style>@import url('figure.css')</style>
 
   <defs>
     <marker id="arrowhead" orient="auto-start-reverse" markerWidth="10" markerHeight="10"
@@ -21,15 +12,15 @@
   <g transform="translate(104 40)">
     <g>
       <ellipse rx="70" ry="26"/>
-      <text y="5" font-size="16">Subject</text>
+      <text class="middle" y="5" font-size="16">Subject</text>
     </g>
     <g transform="translate(70 0)">
-      <text x="52" y="-5" font-size="16">Predicate</text>
+      <text class="middle" x="52" y="-5" font-size="16">Predicate</text>
       <path d="M0,0 100,0" class="arrow"/>
     </g>
     <g transform="translate(251 0)">
       <ellipse rx="70" ry="26"/>
-      <text y="5" font-size="16">Object</text>
+      <text class="middle" y="5" font-size="16">Object</text>
     </g>
   </g>
 

--- a/spec/rdf-graph.svg
+++ b/spec/rdf-graph.svg
@@ -1,19 +1,36 @@
-<svg viewBox="0 -20.5 329 41" width="329" height="41" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 464 80" xmlns="http://www.w3.org/2000/svg">
+
   <style type="text/css">
-ellipse, polyline { stroke-width: 1; stroke: black; }
-ellipse { fill: white; }
-polyline { fill: none; }
-text { fill: black; text-anchor: middle; font-family: Helvetica, sans-serif; }
+    :root { --bg: #fff; --solid: #eee; --mid: #aaa; --fg: #000 }
+    @media (prefers-color-scheme: dark) {
+      :root { --bg: #000; --solid: #333; --mid: #777; --fg: #eee }
+    }
+    svg { background-color: var(--bg); stroke: none; }
+    ellipse { stroke: var(--fg); fill: var(--solid) }
+    path.arrow { stroke: var(--fg); marker-end: url(#arrowhead) }
+    text { fill: var(--fg); text-anchor: middle; font-family: Helvetica, sans-serif; }
   </style>
-  <g transform="translate(55 0)">
-    <ellipse rx="54" ry="20"/><text y="5" font-size="16">Subject</text>
+
+  <defs>
+    <marker id="arrowhead" orient="auto-start-reverse" markerWidth="10" markerHeight="10"
+            refX="0" refY="5">
+      <path d="M0,0 V10 L10,5 Z" fill="context-stroke" />
+    </marker>
+  </defs>
+
+  <g transform="translate(104 40)">
+    <g>
+      <ellipse rx="70" ry="26"/>
+      <text y="5" font-size="16">Subject</text>
+    </g>
+    <g transform="translate(70 0)">
+      <text x="52" y="-5" font-size="16">Predicate</text>
+      <path d="M0,0 100,0" class="arrow"/>
+    </g>
+    <g transform="translate(251 0)">
+      <ellipse rx="70" ry="26"/>
+      <text y="5" font-size="16">Object</text>
+    </g>
   </g>
-  <g transform="translate(274 0)">
-    <ellipse rx="54" ry="20"/><text y="5" font-size="16">Object</text>
-  </g>
-  <g transform="translate(109 0)">
-    <text x="52" y="-5" font-size="16">Predicate</text>
-    <polyline points="0,0 109,0"/>
-    <polyline points="98,-5 110,0 98,5"/>
-  </g>
+
 </svg>

--- a/spec/triple-term.svg
+++ b/spec/triple-term.svg
@@ -1,26 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0.0 0.0 464 324">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0.0 0.0 464 324">
 
-  <style>
-    :root { --bg: #fff; --solid: #eee; --mid: #aaa; --fg: #000 }
-    @media (prefers-color-scheme: dark) {
-      :root { --bg: #000; --solid: #333; --mid: #777; --fg: #eee }
-    }
-    svg { background-color: var(--bg); stroke: none; }
-    ellipse { stroke: var(--fg); fill: var(--solid) }
-    path.arrow { stroke: var(--fg); marker-end: url(#arrowhead) }
-    text { fill: var(--fg); font-family: Helvetica, sans-serif; }
-    text.middle { text-anchor: middle }
-    text.italic { font-style: italic }
-    path.reifies { stroke: var(--fg); stroke-width: 1; marker-start: url(#arrowhead); fill: none }
-    .unasserted > path.arrow { stroke: var(--mid); stroke-dasharray: 8; marker-end: url(#arrowhead) }
-    .unasserted > text { fill: var(--mid) }
-    .unlinked > ellipse { stroke: var(--mid) }
-  </style>
+  <style>@import url('figure.css')</style>
 
   <defs>
-    <marker id="arrowhead" orient="auto-start-reverse" markerWidth="10" markerHeight="10"
-            refX="0" refY="5">
+    <marker id="arrowhead"
+            orient="auto-start-reverse" markerWidth="10" markerHeight="10" refX="0" refY="5">
       <path d="M0,0 V10 L10,5 Z" fill="context-stroke" />
+    </marker>
+    <marker id="arrowhead-abstract"
+            orient="auto-start-reverse" markerWidth="10" markerHeight="10" refX="0" refY="5">
+      <path d="M0,0 V10 L10,5 Z" />
     </marker>
   </defs>
 
@@ -29,7 +18,7 @@
       <ellipse rx="80" ry="36"/>
       <text class="middle" y="6">:Alice</text>
     </g>
-    <g transform="translate(180, 2)" class="unasserted">
+    <g transform="translate(180, 2)" class="abstract">
       <path d="M0,0 92,0" class="arrow"/>
       <text x="26" y="-8">:name</text>
     </g>

--- a/spec/triple-term.svg
+++ b/spec/triple-term.svg
@@ -1,53 +1,62 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0.0 0.0 464 296">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0.0 0.0 464 324">
 
   <style>
-      svg { fill: none; stroke: none; }
-      ellipse { stroke: #000 }
-      path.arrow { stroke: #000; marker-end: url(#arrowhead) }
-      text { fill: #000; font-family: Helvetica, sans-serif; }
-      text.middle { text-anchor: middle }
-      text.italic { font-style: italic }
-      .rei { fill: #fff }
-      rect.quoted { fill: #ccc; stroke: #000; }
-      rect.reifies { fill: #fff; stroke: #000; }
+    :root { --bg: #fff; --solid: #eee; --mid: #aaa; --fg: #000 }
+    @media (prefers-color-scheme: dark) {
+      :root { --bg: #000; --solid: #333; --mid: #777; --fg: #eee }
+    }
+    svg { background-color: var(--bg); stroke: none; }
+    ellipse { stroke: var(--fg); fill: var(--solid) }
+    path.arrow { stroke: var(--fg); marker-end: url(#arrowhead) }
+    text { fill: var(--fg); font-family: Helvetica, sans-serif; }
+    text.middle { text-anchor: middle }
+    text.italic { font-style: italic }
+    path.reifies { stroke: var(--fg); stroke-width: 1; marker-start: url(#arrowhead); fill: none }
+    .unasserted > path.arrow { stroke: var(--mid); stroke-dasharray: 8; marker-end: url(#arrowhead) }
+    .unasserted > text { fill: var(--mid) }
+    .unlinked > ellipse { stroke: var(--mid) }
   </style>
 
   <defs>
-    <marker id="arrowhead" orient="auto" markerWidth="8" markerHeight="8"
-            refX="0" refY="3">
-      <path d="M0,0 V6 L8,3 Z" fill="#000" />
+    <marker id="arrowhead" orient="auto-start-reverse" markerWidth="10" markerHeight="10"
+            refX="0" refY="5">
+      <path d="M0,0 V10 L10,5 Z" fill="context-stroke" />
     </marker>
   </defs>
 
-  <g transform="translate(230, 256)">
-    <ellipse rx="80" ry="36"/>
-    <text class="middle" y="6">:Bob</text>
-  </g>
-  <rect class="quoted" x="5" y="2" width="453" height="128" rx="16"/>
-
-  <g transform="translate(230, 128)">
-    <ellipse class="rei" rx="60" ry="24"/>
-    <text class="middle italic" y="6">_:rei-1</text>
-    <text class="italic" x="72" y="-6">rdf:reifies</text>
-  </g>
-  <g transform="translate(230, 68)">
-    <path d="M0,84 0,142" class="arrow"/>
-    <text x="8" y="118">:accordingTo</text>
-  </g>
-
-  <g transform="translate(0, 58)">
-    <g transform="translate(100, 0)">
+  <g transform="translate(0, 48)">
+    <g transform="translate(100, 0)" class="unlinked">
       <ellipse rx="80" ry="36"/>
       <text class="middle" y="6">:Alice</text>
     </g>
-    <g transform="translate(180, 2)">
-      <path d="M0,0 95,0" class="arrow"/>
+    <g transform="translate(180, 2)" class="unasserted">
+      <path d="M0,0 92,0" class="arrow"/>
       <text x="26" y="-8">:name</text>
     </g>
-    <g transform="translate(363, 0)">
+    <g transform="translate(363, 0)" class="unlinked">
       <ellipse rx="80" ry="36"/>
       <text class="middle" y="6">"Alice"</text>
     </g>
+  </g>
+
+  <g transform="translate(230, 60)">
+    <path d="m 0,1 c -8,16 -16,24 0,34 s 0,24 0,37" class="reifies"/>
+    <text class="italic" dx="16" dy="50">rdf:reifies</text>
+  </g>
+
+  <g transform="translate(228, 150)">
+    <ellipse rx="48" ry="18"/>
+    <text class="middle italic" y="6">:rei-1</text>
+  </g>
+
+  <g transform="translate(230, 84)">
+    <path d="M0,84 0,140" class="arrow"/>
+    <text x="8" y="118">:accordingTo</text>
+  </g>
+
+  <g transform="translate(230, 272)">
+    <ellipse rx="80" ry="36"/>
+    <text class="middle" y="6">:Bob</text>
   </g>
 
 </svg>


### PR DESCRIPTION
Major changes:
* Aligns the visual representation of reifying triples with the Primer (using arrows pointing to the arcs, and a dashed arrow for unasserted triple terms).
* Updates textual descriptions about triple terms.
* Enables dark mode for HTML and SVG (SVGs should adapt individually; including in previews in this PR).

Minor changes:
* Uses a uniform width of all three figures in the document (can still be overridden).
* Removes links to the now outdated google docs diagram versions. 

The textual descriptions aim to align with recent updates clarifying triples-as-terms and propositions. The visual style might prompt further debate; hence I wanted to make sure dark mode is taken into account if we decide to do further changes.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/niklasl/rdf-concepts/pull/168.html" title="Last updated on Mar 20, 2025, 11:28 PM UTC (dfd4025)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/168/0301846...niklasl:dfd4025.html" title="Last updated on Mar 20, 2025, 11:28 PM UTC (dfd4025)">Diff</a>