### PR TITLE
Reorders definitions in RDF-concepts, and add definitions for 'ground' and 'atomic'

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -591,6 +591,11 @@
 
     <p>The three components (|s|, |p|, |o|) of an [=RDF triple=] are respectively called the <dfn class=export >subject</dfn>, <dfn class=export >predicate</dfn> and <dfn class=export >object</dfn> of the triple.</p>
 
+    <p>The set of <span id="dfn-nodes"><!-- obsolete term--></span><dfn data-lt="node">nodes</dfn> of an <a>RDF graph</a>
+      is the set of <a>subjects</a> and <a>objects</a> of the <a>asserted triples</a> of the graph.
+      It is possible for a [=predicate=] [=IRI=] to also occur as a [=node=] in
+      the same graph.</p>
+
     <p><dfn>Triple equality</dfn>:
       Two triples (|s|, |p|, |o|) and (<var>s'</var>, <var>p'</var>, <var>o'</var>)
       are equal (the same [=RDF triple=]) if and only if all of the following three conditions hold.</p>
@@ -632,11 +637,6 @@
       are always distinguishable, even if they are otherwise based on the same [=string=].
       For example, the IRI `http://example.org/` is not equal to a literal whose [=lexical form=] is `http://example.org/`.
     </aside>
-
-    <p>The set of <span id="dfn-nodes"><!-- obsolete term--></span><dfn data-lt="node">nodes</dfn> of an <a>RDF graph</a>
-      is the set of <a>subjects</a> and <a>objects</a> of the <a>asserted triples</a> of the graph.
-      It is possible for a [=predicate=] [=IRI=] to also occur as a [=node=] in
-      the same graph.</p>
 
     <p>The set of [=RDF terms=] <dfn class=export data-lt="appear">appearing</dfn> in an [=RDF triple=] |t| is defined inductively as follows:</p>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -647,6 +647,12 @@
 
     <p>By extension, an [=RDF term=] is said to [=appear=] in an [=RDF graph=] if it appears in an [=asserted triple=] of that graph. An [=RDF triple=] is said to [=appear=] in an [=RDF graph=] if it is either an [=asserted triple=] of that graph or a [=triple term=] [=appearing=] in that graph.</p>
 
+    <p>
+      An [=RDF term=] is said to be <dfn>ground</dfn> if it is an [=IRI=], a [=literal=], or a [=triple term=] in which only [=ground=] terms [=appear=].
+      By extension, an [=RDF triple=] is said to be [=ground=] if its [=subject=], [=predicate=] and [=object=] are all ground.
+      An [=RDF graph=] is said to be [=ground=] if all its [=asserted=] triples are [=ground=].
+    </p>
+
   </section>
 
   <section id="section-IRIs">

--- a/spec/index.html
+++ b/spec/index.html
@@ -620,6 +620,10 @@
       <a>blank nodes</a>, and <a>triple terms</a> are collectively known as
       <span id="dfn-rdf-terms"><!-- obsolete term--></span><dfn data-lt="rdf term">RDF terms</dfn>.</p>
 
+    <p>
+      [=IRIs=], [=literals=] and [=blank nodes=] are said to be <dfn data-lt-no-plural>atomic</dfn> [=RDF terms=].
+    </p>
+
     <p><dfn>RDF term equality</dfn>:
       Two [=RDF terms=] |t| and <var>t'</var> are equal (the same [=RDF term=]) if and only if
       one of the following four conditions holds:</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -637,6 +637,16 @@
       is the set of <a>subjects</a> and <a>objects</a> of the <a>asserted triples</a> of the graph.
       It is possible for a [=predicate=] [=IRI=] to also occur as a [=node=] in
       the same graph.</p>
+
+    <p>The set of [=RDF terms=] <dfn class=export data-lt="appear">appearing</dfn> in an [=RDF triple=] |t| is defined inductively as follows:</p>
+
+    <ul>
+      <li>The [=subject=], [=predicate=] and [=object=] of |t| [=appear=] in |t|.
+      <li>If the [=object=] of |t| is an [=RDF triple=] |t2|, then any [=RDF term=] [=appearing=] in |t2| also [=appears=] in |t|.
+    </ul>
+
+    <p>By extension, an [=RDF term=] is said to [=appear=] in an [=RDF graph=] if it appears in an [=asserted triple=] of that graph. An [=RDF triple=] is said to [=appear=] in an [=RDF graph=] if it is either an [=asserted triple=] of that graph or a [=triple term=] [=appearing=] in that graph.</p>
+
   </section>
 
   <section id="section-IRIs">
@@ -934,15 +944,6 @@
     <p>An [=RDF triple=] used as the [=object=] of another [=triple=] is called a <dfn class=export >triple term</dfn>.
       In a given [=RDF graph=], a [=triple=] can appear as a [=triple term=], an [=asserted triple=], or both.
     </p>
-
-    <p>The set of [=RDF terms=] <dfn class=export data-lt="appear">appearing</dfn> in an [=RDF triple=] |t| is defined inductively as follows:</p>
-
-    <ul>
-      <li>The [=subject=], [=predicate=] and [=object=] of |t| [=appear=] in |t|.
-      <li>If a [=triple term=] |t2| appears in |t|, then any [=RDF term=] [=appearing=] in |t2| also [=appears=] in |t|.
-    </ul>
-
-    <p>By extension, an [=RDF term=] is said to [=appear=] in an [=RDF graph=] if it appears in an [=asserted triple=] of that graph. An [=RDF triple=] is said to [=appear=] in an [=RDF graph=] if it is either an [=asserted triple=] of that graph or a [=triple term=] [=appearing=] in that graph.</p>
 
     <p>Triple term equality:
       Since triple terms are [=triples=], equality of triple terms is the same as [=triple equality=].</p>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/173.html" title="Last updated on Mar 24, 2025, 9:03 AM UTC (6da5cf0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/173/5cc4dbf...6da5cf0.html" title="Last updated on Mar 24, 2025, 9:03 AM UTC (6da5cf0)">Diff</a>