### PR TITLE
Remove atomic RDF term definition

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -620,10 +620,6 @@
       <a>blank nodes</a>, and <a>triple terms</a> are collectively known as
       <span id="dfn-rdf-terms"><!-- obsolete term--></span><dfn data-lt="rdf term">RDF terms</dfn>.</p>
 
-    <p>
-      [=IRIs=], [=literals=] and [=blank nodes=] are said to be <dfn data-lt-no-plural>atomic</dfn> [=RDF terms=].
-    </p>
-
     <p><dfn>RDF term equality</dfn>:
       Two [=RDF terms=] |t| and <var>t'</var> are equal (the same [=RDF term=]) if and only if
       one of the following four conditions holds:</p>


### PR DESCRIPTION
Not used anywhere in the document


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/179.html" title="Last updated on Mar 27, 2025, 4:25 PM UTC (f92df22)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/179/2096fd6...f92df22.html" title="Last updated on Mar 27, 2025, 4:25 PM UTC (f92df22)">Diff</a>