### PR TITLE
Declare advisement level keywords for non-normative content in Conformance

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -503,6 +503,10 @@
 </section>
 
 <section id="conformance">
+  <p id="advisement-levels">The key words “strongly encouraged”, “strongly
+  discouraged”, “encouraged", “discouraged", “can", “cannot”, “could”, “could
+  not”, “might”, and “might not” are usedfor non-normative content.</p>
+
   <p>This specification, <em>RDF 1.2 Concepts and Abstract Syntax</em>,
     defines a data model and related terminology for use in
     other specifications, such as


### PR DESCRIPTION
This is a [correction class 2 change](https://www.w3.org/policies/process/#class-2) updating the #conformance section to clarify the use of #advisement-levels terms.

This proposal is based on the suggestion in https://github.com/w3c/rdf-concepts/issues/181#issuecomment-2772191395 to better distinguish the terminology used in normative and non-normative content. That is, continue to reserve RFC keywords in uppercase for normative content, and only use advisement level terms in lowercase for non-normative content.