### PR TITLE
Add version announcement section

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -515,9 +515,9 @@
       or both.</p>
 
     <p>When the version is indicated both in a media-type parameter and in syntax,
-	    they are expected to be the same.
-	    If they differ,
-	    parsers use the version from the media-type parameter and might emit a warning about the mismatch.</p>
+      they are expected to be the same.
+      If they differ,
+      parsers use the version from the media-type parameter and might emit a warning about the mismatch.</p>
 
     <p>To retain compability that is as broad as possible with older parsers,
       only RDF documents that make use of RDF 1.2-specific functionality

--- a/spec/index.html
+++ b/spec/index.html
@@ -525,7 +525,7 @@
       of RDF 1.2-specific functionality it is discouraged to announce a version).</p>
 
     <p>To announce the version in the HTTP responses using the Content-Type header,
-      the <code>version</code> parameter is expected to be used,
+      the server is expected to use the <code>version</code> parameter,
       as illustrated in the following example response.</p>
 
     <pre class="box http">HTTP/1.1 200 OK

--- a/spec/index.html
+++ b/spec/index.html
@@ -364,43 +364,6 @@
     <p>Note that a <a>triple term</a> may also have another <a>triple term</a> as an <a>object</a>.</p>
   </section>
 
-  <section id="section-version-announcement">
-    <h3>RDF Version Announcement</h3>
-
-    <p>To allow RDF parsers to error or warn about unsupported RDF versions as early as possible,
-      RDF serialization formats are expected to allow a version to be specified,
-      via either the HTTP Content-Type header,
-      a version announcement in a format-specific syntax,
-      or both.</p>
-
-    <p>If the version is announced in both the Content-Type header and the syntax,
-      they are expected to be equal.</p>
-
-    <p>To retain compability that is as broad as possible with older parsers,
-      only RDF documents that make use of RDF 1.2-specific functionality
-      are encouraged to announce their version (i.e., for RDF documents that do not make use
-      of RDF 1.2-specific functionality it is discouraged to announce a version).</p>
-
-    <p>To announce the version in the HTTP responses using the Content-Type header,
-      the <code>version</code> parameter is expected to be used,
-      as illustrated in the following example response.</p>
-
-    <pre class="box http">HTTP/1.1 200 OK
-Content-Type: text/turtle; version=1.2
-Location: http://example.com/document.ttl
-    </pre>
-
-    <p>When requesting an RDF document from an HTTP server, the <code>version</code> parameter
-      can be used during <a data-cite="webarch#frag-coneg">content negotiation</a> [[WEBARCH]]
-      by including it in the <code>Accept</code> request header,
-      as illustrated in the following example request.</p>
-	
-    <pre class="box http">GET /document.ttl HTTP/1.1
-Host: example.com
-Accept: text/turtle; version=1.2
-    </pre>
-  </section>
-
   <section id="change-over-time">
     <h3>RDF and Change over Time</h3>
 
@@ -540,6 +503,43 @@ Accept: text/turtle; version=1.2
       and different ordering of triples. While these aspects can have great
       effect on the convenience of working with the <a>RDF document</a>,
       they are not significant for its meaning.</p>
+  </section>
+
+  <section id="section-version-announcement">
+    <h3>RDF Version Announcement</h3>
+
+    <p>To allow RDF parsers to error or warn about unsupported RDF versions as early as possible,
+      RDF serialization formats are expected to allow a version to be specified,
+      via either the HTTP Content-Type header,
+      a version announcement in a format-specific syntax,
+      or both.</p>
+
+    <p>If the version is announced in both the Content-Type header and the syntax,
+      they are expected to be equal.</p>
+
+    <p>To retain compability that is as broad as possible with older parsers,
+      only RDF documents that make use of RDF 1.2-specific functionality
+      are encouraged to announce their version (i.e., for RDF documents that do not make use
+      of RDF 1.2-specific functionality it is discouraged to announce a version).</p>
+
+    <p>To announce the version in the HTTP responses using the Content-Type header,
+      the <code>version</code> parameter is expected to be used,
+      as illustrated in the following example response.</p>
+
+    <pre class="box http">HTTP/1.1 200 OK
+Content-Type: text/turtle; version=1.2
+Location: http://example.com/document.ttl
+    </pre>
+
+    <p>When requesting an RDF document from an HTTP server, the <code>version</code> parameter
+      can be used during <a data-cite="webarch#frag-coneg">content negotiation</a> [[WEBARCH]]
+      by including it in the <code>Accept</code> request header,
+      as illustrated in the following example request.</p>
+	
+    <pre class="box http">GET /document.ttl HTTP/1.1
+Host: example.com
+Accept: text/turtle; version=1.2
+    </pre>
   </section>
 </section>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -365,17 +365,20 @@
   </section>
   
   <section id="section-version-announcement">
-    <h3>RDF version announcement</h3>
+    <h3>RDF Version Announcement</h3>
 	
     <p>To allow RDF parsers to error or warn about unsupported RDF versions as early as possible,
-		RDF serialization formats SHOULD allow a version to be specified,
-		either via the HTTP Content-Type header,
+		RDF serialization formats are expected to allow a version to be specified,
+		via either the HTTP Content-Type header,
 		a version announcement in the format-specific syntax,
 		or both.</p>
 
-	<p>If the version is announced in both the Content-Type header and in the syntax, they MUST be equal.</p>
+	<p>If the version is announced in both the Content-Type header and in the syntax, they are expected to be equal.</p>
 	
-	<p>To retain compability that is as broad as possible with older parsers, only RDF documents that make use of RDF 1.2-specific functionality SHOULD announce their version.</p>
+	<p>To retain compability that is as broad as possible with older parsers,
+	  only RDF documents that make use of RDF 1.2-specific functionality
+	  SHOULD announce their version (i.e., RDF documents that do not make use
+	  of RDF 1.2-specific functionality SHOULD NOT announce their version).</p>
 	
 	<p>To announce the version in the HTTP responses using the Content-Type header, the <code>version</code> parameter MUST be used.</p>
 	
@@ -384,8 +387,9 @@ Content-Type: text/turtle; version=1.2
 Location: http://example.com/document.ttl
 	</pre>
 	
-	<p>This <code>version</code> parameter MAY be used in HTTP requests using the Accept header
-		when requesting an RDF document from a server during <a data-cite="webarch#frag-coneg">content negotiation</a> [[WEBARCH]].</p>
+	<p>When requesting an RDF document from an HTTP server, the <code>version</code> parameter
+	MAY be used during <a data-cite="webarch#frag-coneg">content negotiation</a> [[WEBARCH]]
+	by including it in the <code>Accept</code> request header.</p>
 		
 	<pre class="box http">GET /document.ttl HTTP/1.1
 Host: example.com
@@ -2309,7 +2313,7 @@ Accept: text/turtle; version=1.2
 
   <ul>
 	<li>Added <a href="#section-version-announcement"class="sectionRef"></a>
-		for announcing RDF versions in RDF documents via the HTTP Content-Type header or syntax.</li>
+		for announcing RDF versions in RDF documents via the HTTP Content-Type header and/or syntax.</li>
     <li>Added <a href="#section-classic-full-interop" class="sectionRef"></a>
       for informative mappings between RDF [=Full=] and RDF [=Classic=].</li>
     <li>Added <a href="#section-dataset-quad" class="sectionRef"></a>

--- a/spec/index.html
+++ b/spec/index.html
@@ -363,42 +363,42 @@
 
     <p>Note that a <a>triple term</a> may also have another <a>triple term</a> as an <a>object</a>.</p>
   </section>
-  
+
   <section id="section-version-announcement">
     <h3>RDF Version Announcement</h3>
-	
-    <p>To allow RDF parsers to error or warn about unsupported RDF versions as early as possible,
-		RDF serialization formats are expected to allow a version to be specified,
-		via either the HTTP Content-Type header,
-		a version announcement in a format-specific syntax,
-		or both.</p>
 
-	<p>If the version is announced in both the Content-Type header and the syntax,
-	  they are expected to be equal.</p>
-	
-	<p>To retain compability that is as broad as possible with older parsers,
-	  only RDF documents that make use of RDF 1.2-specific functionality
-	  are encouraged to announce their version (i.e., for RDF documents that do not make use
-	  of RDF 1.2-specific functionality it is discouraged to announce a version).</p>
-	
-	<p>To announce the version in the HTTP responses using the Content-Type header,
-	  the <code>version</code> parameter is expected to be used,
-	  as illustrated in the following example response.</p>
-	
-	<pre class="box http">HTTP/1.1 200 OK
+    <p>To allow RDF parsers to error or warn about unsupported RDF versions as early as possible,
+      RDF serialization formats are expected to allow a version to be specified,
+      via either the HTTP Content-Type header,
+      a version announcement in a format-specific syntax,
+      or both.</p>
+
+    <p>If the version is announced in both the Content-Type header and the syntax,
+      they are expected to be equal.</p>
+
+    <p>To retain compability that is as broad as possible with older parsers,
+      only RDF documents that make use of RDF 1.2-specific functionality
+      are encouraged to announce their version (i.e., for RDF documents that do not make use
+      of RDF 1.2-specific functionality it is discouraged to announce a version).</p>
+
+    <p>To announce the version in the HTTP responses using the Content-Type header,
+      the <code>version</code> parameter is expected to be used,
+      as illustrated in the following example response.</p>
+
+    <pre class="box http">HTTP/1.1 200 OK
 Content-Type: text/turtle; version=1.2
 Location: http://example.com/document.ttl
-	</pre>
+    </pre>
+
+    <p>When requesting an RDF document from an HTTP server, the <code>version</code> parameter
+      can be used during <a data-cite="webarch#frag-coneg">content negotiation</a> [[WEBARCH]]
+      by including it in the <code>Accept</code> request header,
+      as illustrated in the following example request.</p>
 	
-	<p>When requesting an RDF document from an HTTP server, the <code>version</code> parameter
-	can be used during <a data-cite="webarch#frag-coneg">content negotiation</a> [[WEBARCH]]
-	by including it in the <code>Accept</code> request header,
-	as illustrated in the following example request.</p>
-		
-	<pre class="box http">GET /document.ttl HTTP/1.1
+    <pre class="box http">GET /document.ttl HTTP/1.1
 Host: example.com
 Accept: text/turtle; version=1.2
-	</pre>
+    </pre>
   </section>
 
   <section id="change-over-time">

--- a/spec/index.html
+++ b/spec/index.html
@@ -377,10 +377,10 @@
 	
 	<p>To retain compability that is as broad as possible with older parsers,
 	  only RDF documents that make use of RDF 1.2-specific functionality
-	  SHOULD announce their version (i.e., RDF documents that do not make use
+	  are encouraged to announce their version (i.e., RDF documents that do not make use
 	  of RDF 1.2-specific functionality SHOULD NOT announce their version).</p>
 	
-	<p>To announce the version in the HTTP responses using the Content-Type header, the <code>version</code> parameter MUST be used.</p>
+	<p>To announce the version in the HTTP responses using the Content-Type header, the <code>version</code> parameter is expected to be used.</p>
 	
 	<pre class="box http">HTTP/1.1 200 OK
 Content-Type: text/turtle; version=1.2
@@ -388,7 +388,7 @@ Location: http://example.com/document.ttl
 	</pre>
 	
 	<p>When requesting an RDF document from an HTTP server, the <code>version</code> parameter
-	MAY be used during <a data-cite="webarch#frag-coneg">content negotiation</a> [[WEBARCH]]
+	can be used during <a data-cite="webarch#frag-coneg">content negotiation</a> [[WEBARCH]]
 	by including it in the <code>Accept</code> request header.</p>
 		
 	<pre class="box http">GET /document.ttl HTTP/1.1

--- a/spec/index.html
+++ b/spec/index.html
@@ -370,17 +370,20 @@
     <p>To allow RDF parsers to error or warn about unsupported RDF versions as early as possible,
 		RDF serialization formats are expected to allow a version to be specified,
 		via either the HTTP Content-Type header,
-		a version announcement in the format-specific syntax,
+		a version announcement in a format-specific syntax,
 		or both.</p>
 
-	<p>If the version is announced in both the Content-Type header and in the syntax, they are expected to be equal.</p>
+	<p>If the version is announced in both the Content-Type header and the syntax,
+	  they are expected to be equal.</p>
 	
 	<p>To retain compability that is as broad as possible with older parsers,
 	  only RDF documents that make use of RDF 1.2-specific functionality
-	  are encouraged to announce their version (i.e., RDF documents that do not make use
-	  of RDF 1.2-specific functionality SHOULD NOT announce their version).</p>
+	  are encouraged to announce their version (i.e., for RDF documents that do not make use
+	  of RDF 1.2-specific functionality it is discouraged to announce a version).</p>
 	
-	<p>To announce the version in the HTTP responses using the Content-Type header, the <code>version</code> parameter is expected to be used.</p>
+	<p>To announce the version in the HTTP responses using the Content-Type header,
+	  the <code>version</code> parameter is expected to be used,
+	  as illustrated in the following example response.</p>
 	
 	<pre class="box http">HTTP/1.1 200 OK
 Content-Type: text/turtle; version=1.2
@@ -389,7 +392,8 @@ Location: http://example.com/document.ttl
 	
 	<p>When requesting an RDF document from an HTTP server, the <code>version</code> parameter
 	can be used during <a data-cite="webarch#frag-coneg">content negotiation</a> [[WEBARCH]]
-	by including it in the <code>Accept</code> request header.</p>
+	by including it in the <code>Accept</code> request header,
+	as illustrated in the following example request.</p>
 		
 	<pre class="box http">GET /document.ttl HTTP/1.1
 Host: example.com
@@ -2312,8 +2316,8 @@ Accept: text/turtle; version=1.2
   <h2>Changes between RDF 1.1 and RDF 1.2</h2>
 
   <ul>
-	<li>Added <a href="#section-version-announcement"class="sectionRef"></a>
-		for announcing RDF versions in RDF documents via the HTTP Content-Type header and/or syntax.</li>
+    <li>Added <a href="#section-version-announcement"class="sectionRef"></a>
+      for announcing RDF versions in RDF documents via the HTTP Content-Type header and/or syntax.</li>
     <li>Added <a href="#section-classic-full-interop" class="sectionRef"></a>
       for informative mappings between RDF [=Full=] and RDF [=Classic=].</li>
     <li>Added <a href="#section-dataset-quad" class="sectionRef"></a>

--- a/spec/index.html
+++ b/spec/index.html
@@ -363,6 +363,35 @@
 
     <p>Note that a <a>triple term</a> may also have another <a>triple term</a> as an <a>object</a>.</p>
   </section>
+  
+  <section id="section-version-announcement">
+    <h3>RDF version announcement</h3>
+	
+    <p>To allow RDF parsers to error or warn about unsupported RDF versions as early as possible,
+		RDF serialization formats SHOULD allow a version to be specified,
+		either via the HTTP Content-Type header,
+		a version announcement in the format-specific syntax,
+		or both.</p>
+
+	<p>If the version is announced in both the Content-Type header and in the syntax, they MUST be equal.</p>
+	
+	<p>To retain compability that is as broad as possible with older parsers, only RDF documents that make use of RDF 1.2-specific functionality SHOULD announce their version.</p>
+	
+	<p>To announce the version in the HTTP responses using the Content-Type header, the <code>version</code> parameter MUST be used.</p>
+	
+	<pre class="box http">HTTP/1.1 200 OK
+Content-Type: text/turtle; version=1.2
+Location: http://example.com/document.ttl
+	</pre>
+	
+	<p>This <code>version</code> parameter MAY be used in HTTP requests using the Accept header
+		when requesting an RDF document from a server during <a data-cite="webarch#frag-coneg">content negotiation</a> [[WEBARCH]].</p>
+		
+	<pre class="box http">GET /document.ttl HTTP/1.1
+Host: example.com
+Accept: text/turtle; version=1.2
+	</pre>
+  </section>
 
   <section id="change-over-time">
     <h3>RDF and Change over Time</h3>
@@ -2279,6 +2308,8 @@
   <h2>Changes between RDF 1.1 and RDF 1.2</h2>
 
   <ul>
+	<li>Added <a href="#section-version-announcement"class="sectionRef"></a>
+		for announcing RDF versions in RDF documents via the HTTP Content-Type header or syntax.</li>
     <li>Added <a href="#section-classic-full-interop" class="sectionRef"></a>
       for informative mappings between RDF [=Full=] and RDF [=Classic=].</li>
     <li>Added <a href="#section-dataset-quad" class="sectionRef"></a>

--- a/spec/index.html
+++ b/spec/index.html
@@ -510,7 +510,7 @@
 
     <p>To allow RDF parsers to error or warn about unsupported RDF versions as early as possible,
       RDF serialization formats are expected to allow a version to be specified,
-      via either the HTTP Content-Type header,
+      via either a media-type parameter,
       a version announcement in a format-specific syntax,
       or both.</p>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -514,8 +514,10 @@
       a version announcement in a format-specific syntax,
       or both.</p>
 
-    <p>If the version is announced in both the Content-Type header and the syntax,
-      they are expected to be equal.</p>
+    <p>When the version is indicated both in a media-type parameter and in syntax,
+	    they are expected to be the same.
+	    If they differ,
+	    parsers use the version from the media-type parameter and might emit a warning about the mismatch.</p>
 
     <p>To retain compability that is as broad as possible with older parsers,
       only RDF documents that make use of RDF 1.2-specific functionality

--- a/spec/index.html
+++ b/spec/index.html
@@ -533,8 +533,9 @@ Content-Type: text/turtle; version=1.2
 Location: http://example.com/document.ttl
     </pre>
 
-    <p>When requesting an RDF document from an HTTP server, the <code>version</code> parameter
-      can be used during <a data-cite="webarch#frag-coneg">content negotiation</a> [[WEBARCH]]
+    <p>When requesting an RDF document from an HTTP server, a client 
+      can use the <code>version</code> parameter 
+      during <a data-cite="webarch#frag-coneg">content negotiation</a> [[WEBARCH]],
       by including it in the <code>Accept</code> request header,
       as illustrated in the following example request.</p>
 	


### PR DESCRIPTION
As discussed in https://github.com/w3c/rdf-star-wg/issues/141, this adds a short section to the introduction about version announcement.

I tried to limit the text as much as possible to the common elements across all relevant specs, so that format-specific details can build on top of this.

This could also be a dedicated section outside of the introduction, if that would be preferred.

I did not add myself as editor, since I have not been involved in this spec so far yet, and probably won't be anymore after this change. But please let me know if I should add myself nevertheless.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/187.html" title="Last updated on May 5, 2025, 12:03 PM UTC (5f517ba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/187/5e004e3...5f517ba.html" title="Last updated on May 5, 2025, 12:03 PM UTC (5f517ba)">Diff</a>