### PR TITLE
Link CSS shared by SVGs from index file

### DIFF
--- a/spec/figure.css
+++ b/spec/figure.css
@@ -1,16 +1,16 @@
-:root { --bg: #fff; --solid: #eee; --abstract: #aaa; --fg: #000 }
+svg:root { --bg: #fff; --solid: #eee; --abstract: #aaa; --fg: #000 }
 @media (prefers-color-scheme: dark) {
-  :root { --bg: #000; --solid: #333; --abstract: #777; --fg: #eee }
+  svg:root { --bg: #000; --solid: #333; --abstract: #777; --fg: #eee }
 }
 svg { background-color: var(--bg); stroke: none }
-ellipse { stroke: var(--fg); fill: var(--solid) }
-path.arrow { stroke: var(--fg); marker-end: url(#arrowhead) }
-#arrowhead { fill: var(--fg) }
-text { fill: var(--fg); font-family: Helvetica, sans-serif }
-text.middle { text-anchor: middle }
-text.italic { font-style: italic }
-path.reifies { stroke: var(--fg); stroke-width: 1; marker-start: url(#arrowhead); fill: none }
-.abstract > path.arrow { stroke: var(--abstract); stroke-dasharray: 8; marker-end: url(#arrowhead-abstract) }
-#arrowhead-abstract { fill: var(--abstract) }
-.abstract > text { fill: var(--abstract) }
-.unlinked > ellipse { stroke: var(--abstract) }
+svg ellipse { stroke: var(--fg); fill: var(--solid) }
+svg path.arrow { stroke: var(--fg); marker-end: url(#arrowhead) }
+svg #arrowhead { fill: var(--fg) }
+svg text { fill: var(--fg); font-family: Helvetica, sans-serif }
+svg text.middle { text-anchor: middle }
+svg text.italic { font-style: italic }
+svg path.reifies { stroke: var(--fg); stroke-width: 1; marker-start: url(#arrowhead); fill: none }
+svg .abstract > path.arrow { stroke: var(--abstract); stroke-dasharray: 8; marker-end: url(#arrowhead-abstract) }
+svg #arrowhead-abstract { fill: var(--abstract) }
+svg .abstract > text { fill: var(--abstract) }
+svg .unlinked > ellipse { stroke: var(--abstract) }

--- a/spec/index.html
+++ b/spec/index.html
@@ -69,6 +69,8 @@
     content: counters(numsection, ".") ") ";
   }
   </style>
+  <!-- Link CSS used by SVGs, to make Echidna discover and bundle it. -->
+  <link rel="stylesheet" href="figure.css">
 </head>
 
 <body>


### PR DESCRIPTION
This is needed since Echidna cannot detect CSS imports in included SVGs. Selectors are scoped to the `svg` element to avoid collisions. The included CSS has no effect in the HTML since the SVGs are external.

(An alternative to this would be to inline all CSS in the SVGs.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/niklasl/rdf-concepts/pull/188.html" title="Last updated on Apr 21, 2025, 10:20 PM UTC (bcd055c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/188/5e004e3...niklasl:bcd055c.html" title="Last updated on Apr 21, 2025, 10:20 PM UTC (bcd055c)">Diff</a>