### PR TITLE
GH-202: Version Labels

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -546,9 +546,8 @@ Host: example.com
 Accept: text/turtle; version=1.2
     </pre>
     <p>
-      Defined <a>version labels</a> to be used with the <code>version</code> parameter 
-      and in <a>concrete RDF syntax</a> are given in the
-      <a href="#defined-version-labels">section below</a>.
+      Section <a href="#defined-version-labels" class="sectionRef"></a> defines <a>version labels</a>
+      to be used with the <code>version</code> parameter and in <a>concrete RDF syntax</a>.
     </p>
   </section>
 </section>

--- a/spec/index.html
+++ b/spec/index.html
@@ -545,6 +545,11 @@ Location: http://example.com/document.ttl
 Host: example.com
 Accept: text/turtle; version=1.2
     </pre>
+    <p>
+      Defined <a>version labels</a> to be used with the <code>version</code> parameter 
+      and in <a>concrete RDF syntax</a> are given in the
+      <a href="#defined-version-labels">section below</a>.
+    </p>
   </section>
 </section>
 
@@ -576,6 +581,41 @@ Accept: text/turtle; version=1.2
     another specification.</p>
   <p class="issue" data-number="70">
     Change "Classic Conformance" to "Basic Conformance" and define them as profiles.</p>
+
+  <section id="defined-version-labels">
+    <h3>Version Labels</h3>
+    <p>
+      A <dfn>version label</dfn> is a string that identifies the syntax and semantics conformance
+      for the RDF data.
+    </p>
+    <table id="tab-version-labels" class="simple">
+      <caption>Version Labels</caption>
+      <thead>
+        <tr>
+          <th style="text-align: center">Version Label</th>
+          <th style="text-align: center">Syntax</th>
+          <th style="text-align: center">Semantics</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>"1.2"</td>
+          <td>RDF 1.2 syntax</td>
+          <td><a href="https://www.w3.org/TR/rdf12-semantics/">RDF 1.2 Semantics</a></td>
+        </tr>
+        <tr>
+          <td>"1.2-basic"</td>
+          <td>RDF 1.2 syntax without triple terms</td>
+          <td><a href="https://www.w3.org/TR/rdf12-semantics/">RDF 1.2 Semantics</a></td>
+        </tr>
+        <tr>
+          <td>"1.1"</td>
+          <td>RDF 1.1 syntax except for use of a version directive</td>
+          <td><a href="https://www.w3.org/TR/rdf11-semantics/">RDF 1.1 Semantics</a></td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
 
   <section id="rdf-strings">
     <h3>Strings in RDF</h3>


### PR DESCRIPTION
This resolves #202.

The defined labels table is in the normative "conformance" section.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/203.html" title="Last updated on May 6, 2025, 9:28 AM UTC (799e74c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/203/9639896...799e74c.html" title="Last updated on May 6, 2025, 9:28 AM UTC (799e74c)">Diff</a>