### PR TITLE
Clarify section about triple terms and reification

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -369,8 +369,10 @@
       logical relationship; assertions are always made about some
       <a>reifier</a> thereof. There can be multiple, distinct reifiers
       related to the same abstract proposition, such as statements with
-      different sources, or circumstances with different characteristics. Since
-      a proposition so reified does not have to hold, it is possible to make
+      different sources, or circumstances with different characteristics.
+      One reifier may also be used to reify multiple, distinct propositions,
+      expressing different propositional aspects using the same reifier.
+      Since a proposition so reified does not have to hold, it is possible to make
       statements about any kind of statements, including unasserted contradictions.
     </p>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -316,8 +316,8 @@
 
     <p>A <a>triple term</a> is an [=RDF triple=] used as an [=RDF term=]
       in another triple. This use is a reference to a <a>proposition</a>. For
-      the triple term to also be asserted, it must appear in a graph as an <a>asserted
-      triple</a>. This allows for statements to be made about statements
+      the triple term to also be asserted, it must [=appear=] in the same graph as both an <a>asserted
+      triple</a> and an unasserted <a>triple term</a>. This allows for statements to be made about statements
       independent of their assertion within an <a>RDF graph</a>.
     </p>
 
@@ -327,7 +327,7 @@
     <p>
       A <dfn>reifying triple</dfn> is a triple where the <a>predicate</a> is <code>rdf:reifies</code>
       and the <a>object</a> is a <a>triple term</a>.
-      The <a>subject</a> of that triple is called a <dfn>reifier</dfn>, and can be the
+      The <a>subject</a> of that triple is called a <dfn>reifier</dfn>, and it can be the
       subject or object of other triples.
       When the triple term of a <a>reifying triple</a> also [=appears=] in the
       same graph as an <a>asserted triple</a>, the subset of triples that share

--- a/spec/index.html
+++ b/spec/index.html
@@ -369,8 +369,8 @@
     </figure>
 
     <p class="note">
-      The <a>propositions</a> denoted by <a>triple terms</a> are abstract,
-      logical relationships, and assertions are always made about some
+      A <a>proposition</a> denoted by a <a>triple term</a> is an abstract,
+      logical relationship; assertions are always made about some
       <a>reifier</a> thereof. There can be multiple, distinct reifiers
       underlying the same abstract proposition, such as statements with
       different sources, or circumstances with different characteristics. Since

--- a/spec/index.html
+++ b/spec/index.html
@@ -384,8 +384,8 @@
         used to reify multiple, distinct propositions, expressing different
         propositional aspects using the same reifier.</p>
       <p>Since a proposition so reified does not have to hold, it is possible
-        to make statements about any kind of statements, including unasserted
-        contradictions.</p>
+        to make statements about any kind of statement, including an unasserted
+        statement that contradicts another statement, whether asserted or not.</p>
     </div>
 
   </section>

--- a/spec/index.html
+++ b/spec/index.html
@@ -329,7 +329,7 @@
       and the <a>object</a> is a <a>triple</a> denoted by a <a>triple term</a>.
       The <a>subject</a> of that triple is called a <dfn>reifier</dfn>.
       The <a>IRI</a> or <a>blank node</a> denoting a reifier can be the
-      subject or <a>object</a> of other triples.
+    subject or object of other triples.
       A <a>reifying triple</a> whose object is also an <a>asserted triple</a>
       is called a <dfn>triple annotation</dfn>.
     </p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -365,11 +365,13 @@
     </figure>
 
     <p class="note">
-      A <a>proposition</a> denoted by a <a>triple term</a> is an abstract,
-      logical relationship; assertions are always made about some
-      <a>reifier</a> thereof. There can be multiple, distinct reifiers
-      related to the same abstract proposition, such as statements with
-      different sources, or circumstances with different characteristics.
+      Since <a>triple terms</a> denote abstract, logical <a>propositions</a>,
+      they are only allowed as objects of other triples.
+      Assertions involving them should commonly use <a>reifying triples</a>;
+      the <a>reifier</a> is then used for further description.
+      There can be multiple, distinct reifiers related to the same abstract
+      proposition, such as statements with different sources, or circumstances
+      with different characteristics.
       One reifier may also be used to reify multiple, distinct propositions,
       expressing different propositional aspects using the same reifier.
       Since a proposition so reified does not have to hold, it is possible to make

--- a/spec/index.html
+++ b/spec/index.html
@@ -315,10 +315,7 @@
     <h3>Triple Terms and Reification</h3>
 
     <p>A <a>triple term</a> is an [=RDF triple=] used as an [=RDF term=]
-      in the [=object=] position of another triple.</p>
-
-    <p>This usage of a <a>triple term</a> only functions as a reference to a
-      <a>proposition</a>, and does not in itself imply its truth. For this
+      in another triple. This use is a reference to a <a>proposition</a>. For this
       triple to also be asserted, it must appear in a graph as an <a>asserted
       triple</a>. This allows for statements to be made about statements
       independent of their assertion within an <a>RDF graph</a>.

--- a/spec/index.html
+++ b/spec/index.html
@@ -315,8 +315,8 @@
     <h3>Triple Terms and Reification</h3>
 
     <p>A <a>triple term</a> is an [=RDF triple=] used as an [=RDF term=]
-      in another triple. This use is a reference to a <a>proposition</a>. For this
-      triple to also be asserted, it must appear in a graph as an <a>asserted
+      in another triple. This use is a reference to a <a>proposition</a>. For
+      the triple term to also be asserted, it must appear in a graph as an <a>asserted
       triple</a>. This allows for statements to be made about statements
       independent of their assertion within an <a>RDF graph</a>.
     </p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -317,26 +317,29 @@
     <p>A <a>triple term</a> is an [=RDF triple=] used as an [=RDF term=]
       in the [=object=] position of another triple.</p>
 
-    <p>A <a>triple term</a> is not necessarily asserted, allowing
-      statements to be made about other statements that may not be
-      asserted within an <a>RDF graph</a>.
-      This allows statements to be made about relationships that may be contradictory.
-      For a <a>triple term</a> to be asserted,
-      it must also appear in a graph as an <a>asserted triple</a>.</p>
+    <p>This usage of a <a>triple term</a> only functions as a reference to a
+      <a>proposition</a>, and does not in itself imply its truth. For this
+      triple to also be asserted, it must appear in a graph as an <a>asserted
+      triple</a>. This allows for statements to be made about statements
+      independent of their assertion within an <a>RDF graph</a>.
+    </p>
 
-    <p>A <a>triple term</a> can be used as the object of a <a>triple</a> with the predicate <code>rdf:reifies</code>;
-      such a <a>triple</a> is then a <dfn>reifying triple</dfn>.
-      The <a>subject</a> of that <a>triple</a> is called a <dfn>reifier</dfn>.
-      Assertions on the <a>triple term</a> are made using the <a>reifier</a>.
-      A concrete syntax may provide a special notation for specifying <a>reifying triples</a>.</p>
+    <p>
+      When a <a>triple term</a> is used as the object of a <a>triple</a> with
+      the predicate <code>rdf:reifies</code>, such a triple is a
+      <dfn>reifying triple</dfn>.
+      The <a>subject</a> of that triple is called a <dfn>reifier</dfn>.
+      The <a>IRI</a> or <a>blank node</a> denoting a reifier can be the
+      subject or <a>object</a> of other triples.
+      A <a>reifying triple</a> whose object is also an <a>asserted triple</a>
+      is called a <dfn>triple annotation</dfn>.
+    </p>
 
-    <p class="note">Using the <a>reifier</a> as an indirect way of referencing a <a>triple term</a>
-      allows multiple groups of assertions to be separated from each other,
-      which might be necessary if the same <a>triple term</a> was derived from different sources.
-      Assertions are always made using the <a>reifier</a>, which can be the <a>subject</a> or <a>object</a>
-      of different triples.
-      Concrete syntaxes, such as Turtle [[RDF12-TURTLE]],
-      may have shortcuts for capturing a <a>triple term</a> with its <a>reifier</a>.</p>
+    <p>
+      Concrete syntaxes, such as Turtle [[RDF12-TURTLE]], may have shortcuts
+      for specifying <a>reifying triples</a> and <a>triple annotations</a> more
+      succinctly.
+    </p>
 
     <p>The following diagram represents a <a>reifying triple</a> of an unasserted, abstract <a>triple term</a>, and a <a>triple</a> relating the <a>reifier</a> to another resource.</p>
 
@@ -351,7 +354,8 @@
     </figure>
 
     <p>Here is a variation on the graph shown in <a href="#fig-triple-term"></a>. This represents a graph
-      where the <a>triple term</a> corresponds to an <a>asserted triple</a>.
+      where the <a>triple term</a> corresponds to an <a>asserted triple</a>,
+      qualifying the <a>reifying triple</a> as a <a>triple annotation</a>.
     </p>
 
     <figure id="fig-asserted-triple-term">
@@ -365,7 +369,21 @@
       </figcaption>
     </figure>
 
-    <p>Note that a <a>triple term</a> may also have another <a>triple term</a> as an <a>object</a>.</p>
+    <p class="note">
+      The <a>propositions</a> denoted by <a>triple terms</a> are abstract,
+      logical relationships, and assertions are always made about some
+      <a>reifier</a> thereof. There can be multiple, distinct reifiers
+      underlying the same abstract proposition, such as statements with
+      different sources, or circumstances with different characteristics. Since
+      a proposition so reified does not have to hold, it is possible to make
+      statements about any kind of statements, including unasserted contradictions.
+    </p>
+
+    <p class="note">
+      While a <a>triple term</a> may also have another <a>triple term</a> as
+      an <a>object</a>, that is considered an advanced practice beyond the
+      regular use of reifiers.</p>
+
   </section>
 
   <section id="change-over-time">

--- a/spec/index.html
+++ b/spec/index.html
@@ -325,9 +325,10 @@
       A <dfn>reifying triple</dfn> is a triple where the <a>predicate</a> is <code>rdf:reifies</code>
       and the <a>object</a> is a <a>triple term</a>.
       The <a>subject</a> of that triple is called a <dfn>reifier</dfn>, and can be the
-    subject or object of other triples.
-      A <a>reifying triple</a> whose object is also an <a>asserted triple</a>
-      is called a <dfn>triple annotation</dfn>.
+      subject or object of other triples.
+      When the triple term of a <a>reifying triple</a> also [=appears=] in the
+      same graph as an <a>asserted triple</a>, the subset of triples that share
+      the same <a>reifier</a> as subject is called a <dfn>triple annotation</dfn>.
     </p>
 
     <p>
@@ -349,17 +350,17 @@
     </figure>
 
     <p>Here is a variation on the graph shown in <a href="#fig-triple-term"></a>. This represents a graph
-      where the <a>triple term</a> corresponds to an <a>asserted triple</a>,
-      qualifying the <a>reifying triple</a> as a <a>triple annotation</a>.
+      where an <a>asserted triple</a> corresponds to the <a>triple term</a> object of a <a>reifying triple</a>,
+      qualifying the description about this <a>reifier</a> as a <a>triple annotation</a>.
     </p>
 
     <figure id="fig-asserted-triple-term">
       <a href="asserted-triple-term.svg">
         <object data="asserted-triple-term.svg" aria-describedby="fig-asserted-triple-term-alt"
-          aria-label="An RDF graph containing a reifying triple where the triple term corresponds to an asserted triple"></object>
+          aria-label="An RDF graph containing a triple annotation, where the triple term of a reifying triple corresponds to an asserted triple"></object>
       </a>
       <figcaption id="fig-asserted-triple-term-alt">
-        An <a>RDF graph</a> containing a <a>triple annotation</a>, which is a <a>reifying triple</a> whose <a>triple term</a> corresponds to an <a>asserted triple</a>.
+        An <a>RDF graph</a> containing a <a>triple annotation</a>, where the <a>triple term</a> of a <a>reifying triple</a> corresponds to an <a>asserted triple</a>.
         The diagram represents the proposition as a fact using the asserted triple, meaning that the relationship holds.
       </figcaption>
     </figure>

--- a/spec/index.html
+++ b/spec/index.html
@@ -374,11 +374,6 @@
       statements about any kind of statements, including unasserted contradictions.
     </p>
 
-    <p class="note">
-      While a <a>triple term</a> may also have another <a>triple term</a> as
-      an <a>object</a>, that is considered an advanced practice beyond the
-      regular use of reifiers.</p>
-
   </section>
 
   <section id="change-over-time">

--- a/spec/index.html
+++ b/spec/index.html
@@ -326,7 +326,7 @@
 
     <p>
       A <dfn>reifying triple</dfn> is a triple where the <a>predicate</a> is <code>rdf:reifies</code>
-      and the <a>object</a> is a <a>triple</a> denoted by a <a>triple term</a>.
+      and the <a>object</a> is a <a>triple term</a>.
       The <a>subject</a> of that triple is called a <dfn>reifier</dfn>.
       The <a>IRI</a> or <a>blank node</a> denoting a reifier can be the
     subject or object of other triples.

--- a/spec/index.html
+++ b/spec/index.html
@@ -325,9 +325,8 @@
     </p>
 
     <p>
-      When a <a>triple term</a> is used as the object of a <a>triple</a> with
-      the predicate <code>rdf:reifies</code>, such a triple is a
-      <dfn>reifying triple</dfn>.
+      A <dfn>reifying triple</dfn> is a triple where the <a>predicate</a> is <code>rdf:reifies</code>
+      and the <a>object</a> is a <a>triple</a> denoted by a <a>triple term</a>.
       The <a>subject</a> of that triple is called a <dfn>reifier</dfn>.
       The <a>IRI</a> or <a>blank node</a> denoting a reifier can be the
       subject or <a>object</a> of other triples.

--- a/spec/index.html
+++ b/spec/index.html
@@ -365,19 +365,25 @@
       </figcaption>
     </figure>
 
-    <p class="note">
-      Since <a>triple terms</a> denote abstract, logical <a>propositions</a>,
-      they are only allowed as objects of other triples.
-      Assertions involving them should commonly use <a>reifying triples</a>;
-      the <a>reifier</a> is then used for further description.
-      There can be multiple, distinct reifiers related to the same abstract
-      proposition, such as statements with different sources, or circumstances
-      with different characteristics.
-      One reifier may also be used to reify multiple, distinct propositions,
-      expressing different propositional aspects using the same reifier.
-      Since a proposition so reified does not have to hold, it is possible to make
-      statements about any kind of statements, including unasserted contradictions.
-    </p>
+    <div class="note">
+      <p><a>Triple terms</a> always denote abstract, logical <a>propositions</a>,
+        while <a>reifiers</a> may denote a variety of things that are related
+        to these propositions (such as a statement or belief that the
+        proposition holds, or an event or circumstance that makes the
+        proposition true).
+        It is therefore expected that triple terms are commonly used as
+        <a>objects</a> of <a>reifying triples</a>, and that the reifiers
+        (rather than the triple terms) are used in further descriptions.</p>
+      <p>
+        There can be multiple, distinct reifiers related to the same abstract
+        proposition, such as statements with different sources, or
+        circumstances with different characteristics. One reifier may also be
+        used to reify multiple, distinct propositions, expressing different
+        propositional aspects using the same reifier.</p>
+      <p>Since a proposition so reified does not have to hold, it is possible
+        to make statements about any kind of statements, including unasserted
+        contradictions.</p>
+    </div>
 
   </section>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -324,8 +324,7 @@
     <p>
       A <dfn>reifying triple</dfn> is a triple where the <a>predicate</a> is <code>rdf:reifies</code>
       and the <a>object</a> is a <a>triple term</a>.
-      The <a>subject</a> of that triple is called a <dfn>reifier</dfn>.
-      The <a>IRI</a> or <a>blank node</a> denoting a reifier can be the
+      The <a>subject</a> of that triple is called a <dfn>reifier</dfn>, and can be the
     subject or object of other triples.
       A <a>reifying triple</a> whose object is also an <a>asserted triple</a>
       is called a <dfn>triple annotation</dfn>.

--- a/spec/index.html
+++ b/spec/index.html
@@ -364,7 +364,7 @@
           aria-label="An RDF graph containing a reifying triple where the triple term corresponds to an asserted triple"></object>
       </a>
       <figcaption id="fig-asserted-triple-term-alt">
-        An <a>RDF graph</a> containing a <a>reifying triple</a> where the <a>triple term</a> corresponds to an <a>asserted triple</a>.
+        An <a>RDF graph</a> containing a <a>triple annotation</a>, which is a <a>reifying triple</a> whose <a>triple term</a> corresponds to an <a>asserted triple</a>.
         The diagram represents the proposition as a fact using the asserted triple, meaning that the relationship holds.
       </figcaption>
     </figure>

--- a/spec/index.html
+++ b/spec/index.html
@@ -324,7 +324,8 @@
     <p>[=RDF terms=] that [=appear=] in a [=triple term=] have the same
       <a data-lt="denotes">denotation</a> as when they appear in an
       [=asserted triple=] in the <a data-lt="RDF graph">graph</a>.
-      For this reason, we say that triple terms are <i>transparent</i>.</p>
+      For this reason, we say that triple terms are
+      <dfn class="lint-ignore">transparent</dfn>.</p>
 
     <p>
       A <dfn>reifying triple</dfn> is a triple where the <a>predicate</a> is <code>rdf:reifies</code>

--- a/spec/index.html
+++ b/spec/index.html
@@ -321,7 +321,9 @@
       independent of their assertion within an <a>RDF graph</a>.
     </p>
 
-    <p>RDF terms that appear in a triple term have the same denotation as when they appear in an asserted triple in the graph. 
+    <p>[=RDF terms=] that [=appear=] in a [=triple term=] have the same
+      <a data-lt="denotes">denotation</a> as when they appear in an
+      [=asserted triple=] in the <a data-lt="RDF graph">graph</a>.
       For this reason, we say that triple terms are <i>transparent</i>.</p>
 
     <p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -368,7 +368,7 @@
       A <a>proposition</a> denoted by a <a>triple term</a> is an abstract,
       logical relationship; assertions are always made about some
       <a>reifier</a> thereof. There can be multiple, distinct reifiers
-      underlying the same abstract proposition, such as statements with
+      related to the same abstract proposition, such as statements with
       different sources, or circumstances with different characteristics. Since
       a proposition so reified does not have to hold, it is possible to make
       statements about any kind of statements, including unasserted contradictions.


### PR DESCRIPTION
Discussions has indicated that the introduction of triple terms and reification needs some clarification.

Mainly, this proposal:
* Explains triple terms as references to propositions, and clarifying that these as references are not asserted.
* Replaces the problematic formulation:
   > Assertions on the triple term are made using the reifier.

  and moves the theory of that note to the end of the section (and with it the mention of "contradictory").
* Keeps the details about using reifiers in one paragraph of the introduction. That also adds the notion of "triple annotation" alongside "reifying triple", and relates to both in the comment about concrete syntaxes, and from the diagrams.
*  Puts the comment about concrete syntaxes in a distinct paragraph preceding the diagrams.

Finally, it:
* Turns the final comment about nested triple terms into a note, and characterizing it as an advanced practice. (It might even be removed from this section, as there is a corresponding, neutral note in [section 3.1 Triples](https://www.w3.org/TR/rdf12-concepts/#section-triples).)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/niklasl/rdf-concepts/pull/214.html" title="Last updated on Jul 18, 2025, 7:02 PM UTC (0933819)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/214/e98cc0c...niklasl:0933819.html" title="Last updated on Jul 18, 2025, 7:02 PM UTC (0933819)">Diff</a>