### PR TITLE
export normative terms

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -674,7 +674,7 @@ Accept: text/turtle; version=1.2
     <h3>Strings in RDF</h3>
 
     <p>RDF uses Unicode [[Unicode]] as the fundamental representation for string values.
-      Within this, and related specifications, the term <dfn id="dfn-rdf-string" class="export" data-local-lt="string">RDF string</dfn>,
+      Within this and related specifications, the term <dfn id="dfn-rdf-string" class="export" data-local-lt="string">RDF string</dfn>,
       or simply [=string=],
       is used to describe an ordered sequence of zero or more
       <a data-cite="I18N-GLOSSARY#dfn-code-point" class="lint-ignore">Unicode code points</a>
@@ -926,7 +926,7 @@ Accept: text/turtle; version=1.2
       two, three, or four components, as below:</p>
 
     <ol>
-      <li>A <dfn class="export">lexical form</dfn>, being an <a data-lt="string">RDF string</a>.
+      <li>A <dfn class="export">lexical form</dfn>, being an <a data-lt="string">RDF string</a>.</li>
       <li>A <dfn class="export">datatype IRI</dfn>, being an <a>IRI</a>
         identifying a datatype that determines how the lexical form maps
         to a <a>literal value</a>.</li>


### PR DESCRIPTION
Address #152

I broke my own rule of systematically exporting normative definitions...
I strongly felt that the following terms were defined for internal purposes only,
more precisely to help define other terms, so I chose to not export them.

- IRI equality
- Blank node equality
- Literal equality
- Triple equality
- isomorphic RDF-term mapping

I experimented with scoped definition [1]
for genetic terms such as 'atomic', 'node', 'subject'...
but I found that the ergonomic toll was not worth it.
In particular, there is no hint in the HTML
that the definition requires some additional context to be used.

[1] https://respec.org/docs/#scoped-concepts


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/215.html" title="Last updated on Jul 8, 2025, 10:41 AM UTC (bb6d4dd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/215/9714dbd...bb6d4dd.html" title="Last updated on Jul 8, 2025, 10:41 AM UTC (bb6d4dd)">Diff</a>