### PR TITLE
Add notion of transparency in 1.5 Triple Terms and Reification

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -321,8 +321,8 @@
       statements to be made about other statements that may not be
       asserted within an <a>RDF graph</a>.
       This allows statements to be made about relationships that may be contradictory.
-      For a <a>triple term</a> to be asserted,
-      it must also appear in a graph as an <a>asserted triple</a>.</p>
+      For a <a>triple term</a> to be asserted in a graph,
+      it must appear as an <a>asserted triple</a> in that same graph.</p>
 
     <p>RDF terms that appear in a triple term have the same denotation as when they appear in an asserted triple in the graph. 
       For this reason, we say that triple terms are <i>transparent</i>.</p>


### PR DESCRIPTION
Following the discussion in [issue #216](https://github.com/w3c/rdf-concepts/issues/216), I have added after the text:

> ... For a [triple term](https://w3c.github.io/rdf-concepts/spec/#dfn-triple-term) to be asserted, it must also appear in a graph as an [asserted triple](https://w3c.github.io/rdf-concepts/spec/#dfn-asserted-triple).

the following text:

> RDF terms that appear in a triple term have the same denotation as when they appear in an asserted triple in the graph. For this reason, we say that triple terms are _transparent_.

in order avoid people believe that triple terms are like literals.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/unibz-krdb/rdf-concepts-franconi-krdb/pull/219.html" title="Last updated on Jul 17, 2025, 2:32 PM UTC (41ae00d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/219/9714dbd...unibz-krdb:41ae00d.html" title="Last updated on Jul 17, 2025, 2:32 PM UTC (41ae00d)">Diff</a>