### PR TITLE
Rename "atomic" to "basic RDF term"

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -613,9 +613,9 @@ Accept: text/turtle; version=1.2
       with <a>triples</a> that contain <a>triple terms</a>.
       </li>
     <li><dfn id="dfn-basic" class="export" data-local-lt="basic">Basic conformance</dfn>
-      only supports <a data-lt="RDF graph">graphs</a> or <a data-lt="RDF dataset">datasets</a>
+      only supports <a data-lt="RDF graph">graphs</a> and/or <a data-lt="RDF dataset">datasets</a>
       with <a>triples</a> that only contain <a>basic RDF terms</a> &mdash; i.e.,
-      do not contain <a>triple terms</a>.</li>
+      they do not contain <a>triple terms</a>.</li>
   </ul>
   <p class="ednote">The conformance levels described above are tentative,
     and still the subject of group discussion. An alternative to conformance


### PR DESCRIPTION
This replaces "atomic" with "basic RDF term" to address concerns in #172, and makes use of it in the definition of basic conformance.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/niklasl/rdf-concepts/pull/226.html" title="Last updated on Aug 4, 2025, 6:43 PM UTC (d472850)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/226/afeea2c...niklasl:d472850.html" title="Last updated on Aug 4, 2025, 6:43 PM UTC (d472850)">Diff</a>