### PR TITLE
wording of rdf:dirLangString

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -969,8 +969,8 @@ Accept: text/turtle; version=1.2
         and MUST be treated accordingly, that is, in a case-insensitive manner.
         Two [[!BCP47]]-complying strings that differ only by case represent the same [=language tag=].</li>
       <li>If and only if the <a>datatype IRI</a> is
-        <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#dirLangString</code>,
-        a <dfn class="export">base direction</dfn> that MUST be one of the following:<ul>
+        <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#dirLangString</code>, there is a
+        <dfn class="export">base direction</dfn> that MUST be one of the following:<ul>
           <li>`ltr`, indicating that the initial text direction is set to left-to-right</li>
           <li>`rtl`, indicating that the initial text direction is set to right-to-left</li>
         </ul></li>


### PR DESCRIPTION
Mentioned in https://github.com/w3c/rdf-concepts/pull/213#discussion_r2247609031

Without "there is" the connection to the "consists of" is too far away.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/227.html" title="Last updated on Aug 4, 2025, 10:12 AM UTC (3253f5d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/227/404595e...3253f5d.html" title="Last updated on Aug 4, 2025, 10:12 AM UTC (3253f5d)">Diff</a>