### PR TITLE
Use quotation mark consistently

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1362,15 +1362,15 @@ Accept: text/turtle; version=1.2
 
   <dl>
     <dt>Lexical space:</dt>
-    <dd>{“<code>true</code>”, “<code>false</code>”, “<code>1</code>”, “<code>0</code>”}</dd>
+    <dd>{"<code>true</code>", "<code>false</code>", "<code>1</code>", "<code>0</code>"}</dd>
     <dt>Value space:</dt>
     <dd>{<em><strong>true</strong></em>, <em><strong>false</strong></em>}</dd>
     <dt>Lexical-to-value mapping</dt>
     <dd>{
-        &lt;“<code>true</code>”, <em><strong>true</strong></em>&gt;,
-        &lt;“<code>false</code>”, <em><strong>false</strong></em>&gt;,
-        &lt;“<code>1</code>”, <em><strong>true</strong></em>&gt;,
-        &lt;“<code>0</code>”, <em><strong>false</strong></em>&gt;,
+        &lt;"<code>true</code>", <em><strong>true</strong></em>&gt;,
+        &lt;"<code>false</code>", <em><strong>false</strong></em>&gt;,
+        &lt;"<code>1</code>", <em><strong>true</strong></em>&gt;,
+        &lt;"<code>0</code>", <em><strong>false</strong></em>&gt;,
         }</dd>
   </dl>
 
@@ -1384,19 +1384,19 @@ Accept: text/turtle; version=1.2
       <th>Value</th>
     </tr>
     <tr>
-      <td>&lt;“<code>true</code>”, <code>xsd:boolean</code>&gt;</td>
+      <td>&lt;"<code>true</code>", <code>xsd:boolean</code>&gt;</td>
       <td><em><strong>true</strong></em></td>
     </tr>
     <tr>
-      <td>&lt;“<code>false</code>”, <code>xsd:boolean</code>&gt;</td>
+      <td>&lt;"<code>false</code>", <code>xsd:boolean</code>&gt;</td>
       <td><em><strong>false</strong></em></td>
     </tr>
     <tr>
-      <td>&lt;“<code>1</code>”, <code>xsd:boolean</code>&gt;</td>
+      <td>&lt;"<code>1</code>", <code>xsd:boolean</code>&gt;</td>
       <td><em><strong>true</strong></em></td>
     </tr>
     <tr>
-      <td>&lt;“<code>0</code>”, <code>xsd:boolean</code>&gt;</td>
+      <td>&lt;"<code>0</code>", <code>xsd:boolean</code>&gt;</td>
       <td><em><strong>false</strong></em></td>
     </tr>
   </table>


### PR DESCRIPTION
One place uses a 201C-201D pair while other places in the document use 0022-0022 when talking about lexical form.

As this is about lexical form, 0022 is more consistent.

(I came to this because - occasionally - 201C-201D around <code></code> displays with added white space although I can't get this happening in a reproducible way.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/235.html" title="Last updated on Aug 16, 2025, 1:08 PM UTC (0fe37f0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/235/a5862df...0fe37f0.html" title="Last updated on Aug 16, 2025, 1:08 PM UTC (0fe37f0)">Diff</a>