### PR TITLE
explain that rdf:reifies is deliberately abstract

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -390,7 +390,7 @@ For example, the term <code>:Alice</code> from a [=triple term=] and <code>:Alic
 
     <div class="note">
       <p>
-        As already stated, <a>reifiers</a> aim to serve a broad range of use cases:
+        As already stated, <a>reifiers</a> are meant to serve a broad range of use cases:
         statements or beliefs that a proposition is true,
         situations in which the proposition is true,
         events that caused the proposition to become true,


### PR DESCRIPTION
* I moved out the first part of the "note" at the end of §1.5; it felt like it was more than an aside
* I added a paragraph explaining that rdf:reifies is deliberately underspecified

I hesitated explaining that a more specific relationship between (the denotee of) the reifier and the proposition could be derived based on the specific nature of the former, but I considered that it was a bit too much for an intro (§1.5 is quite long already).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/237.html" title="Last updated on Sep 25, 2025, 4:18 PM UTC (0aac35e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/237/22834d5...0aac35e.html" title="Last updated on Sep 25, 2025, 4:18 PM UTC (0aac35e)">Diff</a>