### PR TITLE
better examples with triple terms

### DIFF
--- a/spec/asserted-triple-term.svg
+++ b/spec/asserted-triple-term.svg
@@ -16,11 +16,11 @@
     </g>
     <g transform="translate(180, 2)">
       <path d="M0,0 92,0" class="arrow"/>
-      <text x="26" y="-8">:name</text>
+      <text x="6" y="-8">:familyName</text>
     </g>
     <g transform="translate(363, 0)">
       <ellipse rx="80" ry="36"/>
-      <text class="middle" y="6">"Alice"</text>
+      <text class="middle" y="6">"Liddell"</text>
     </g>
   </g>
 

--- a/spec/triple-term.svg
+++ b/spec/triple-term.svg
@@ -20,11 +20,11 @@
     </g>
     <g transform="translate(180, 2)" class="abstract">
       <path d="M0,0 92,0" class="arrow"/>
-      <text x="26" y="-8">:name</text>
+      <text x="6" y="-8">:familyName</text>
     </g>
     <g transform="translate(363, 0)" class="unlinked">
       <ellipse rx="80" ry="36"/>
-      <text class="middle" y="6">"Alice"</text>
+      <text class="middle" y="6">"Liddell"</text>
     </g>
   </g>
 


### PR DESCRIPTION
This PR changes the examples about triple terms, replacing `:Alice :name "Alice"` with `':Alice :familyName "Liddell"`.

The rationale is that the current example might be confusing, looking like a tautology to the untrained eye. This is all the more true in the prose description of those example: '`:Bob` claims that `:Alice` is named "Alice"'...

I'm requesting reviews to check if this idea has traction. I'm keeping the PR as draft until all the other PRs on §1.5 are closed. Then we will need to:

* [ ] reflect the change in any prose description of the figures in the text