### PR TITLE
State some support exists

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1006,7 +1006,7 @@ Accept: text/turtle; version=1.2
     <section>
       <h4>Representation of Literals</h4>
 
-      <p>Some concrete syntaxes MAY support
+      <p>Some concrete syntaxes support
         <dfn data-lt="simple literal" class="export">simple literals</dfn> consisting of only a
         <a>lexical form</a> without any <a>datatype IRI</a>, <a>language tag</a>, or <a>base direction</a>.
         Simple literals are syntactic sugar for abstract syntax


### PR DESCRIPTION
From https://github.com/w3c/rdf-concepts/pull/238#discussion_r2361269032

"Some concrete syntaxes support ..." -- it is a statement of fact.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/244.html" title="Last updated on Sep 19, 2025, 4:07 PM UTC (3d700fa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/244/628f7c6...3d700fa.html" title="Last updated on Sep 19, 2025, 4:07 PM UTC (3d700fa)">Diff</a>