### PR TITLE
Refer to RDF Primer

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -300,7 +300,7 @@
       the IRIs documented in [[RDF12-SCHEMA]] are the RDF Schema vocabulary.
       RDF Schema can itself be used to define and document additional
       RDF vocabularies. Some such vocabularies are mentioned in the
-      Primer [[RDF12-PRIMER]].</p>
+      [[[RDF12-PRIMER]]] [[RDF12-PRIMER]].</p>
 
     <p>The <a>IRIs</a> in an <a>RDF vocabulary</a> often begin with
       a common substring known as a <dfn>namespace IRI</dfn>.
@@ -365,7 +365,8 @@
       A [=reifier=] may denote a variety of things that are related to the triple term's [=proposition=], 
       such as a statement or belief that the [=proposition=] holds.
       It is expected that the [=reifiers=] (rather than the [=triple terms=]) will be used in further statements.
-      This section describes this common usage.
+      This section briefly describes this common usage.
+      For more examples, refer to the [[[RDF12-PRIMER]]] [[RDF12-PRIMER]].
     </p>
 
     <p>


### PR DESCRIPTION
From the suggestion in https://github.com/w3c/rdf-concepts/pull/245#issuecomment-3327960828

+ Use same style to link to the primer in 1.4


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/246.html" title="Last updated on Sep 24, 2025, 8:18 PM UTC (1d7b19b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/246/c4b7b75...1d7b19b.html" title="Last updated on Sep 24, 2025, 8:18 PM UTC (1d7b19b)">Diff</a>