### PR TITLE
Dealing with pubrules and Gregg's editor status

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -55,7 +55,7 @@
       const gregg = dl.querySelector("dt:nth-of-type(7) + dd");
       dl.removeChild(gregg);
       const leadEditor = editors.cloneNode();
-      leadEditor.innerText = "Lead Editor";
+      leadEditor.innerText = "Lead editor:";
       dl.insertBefore(leadEditor, editors);
       dl.insertBefore(gregg, editors);
     }

--- a/spec/index.html
+++ b/spec/index.html
@@ -20,18 +20,21 @@
       prevRecShortname:     "rdf11-concepts",
 
       editors:  [
+        {
+          name: "Gregg Kellogg",
+          w3cid: "44770",
+          //retiredDate: "2025-09-06", // Respec would automatically move Gregg to the 'Former Editors' section
+          note: "until 2025-09-06",
+          extras: [
+            {name: "in memoriam", class: "former"},
+          ],
+        },
         { name: "Olaf Hartig", w3cid: "112469"},
         { name: "Pierre-Antoine Champin", w3cid: "129656"},
         { name: "Andy Seaborne", w3cid: "29909" }
       ],
 
       formerEditors: [
-        {
-          name: "Gregg Kellogg",
-          retiredDate: "2025-09-06",
-          extras: [{name: "in memoriam", class: "inmemoriam"}],
-
-        },
         { name: "Richard Cyganiak", note: "RDF 1.1" },
         { name: "David Wood", note: "RDF 1.1, Chair" },
         { name: "Markus Lanthaler", note: "RDF 1.1" },
@@ -46,19 +49,7 @@
       doJsonLd:     true,
       wgPublicList: "public-rdf-star-wg",
       maxTocLevel: 2,
-      postProcess: [moveGreggAsLeadEditor],
     };
-
-    function moveGreggAsLeadEditor(config, doc, utils) {
-      const dl = doc.querySelector(".head details dl");
-      const editors = dl.querySelector("dt:nth-of-type(6)");
-      const gregg = dl.querySelector("dt:nth-of-type(7) + dd");
-      dl.removeChild(gregg);
-      const leadEditor = editors.cloneNode();
-      leadEditor.innerText = "Lead editor:";
-      dl.insertBefore(leadEditor, editors);
-      dl.insertBefore(gregg, editors);
-    }
   </script>
   <style>
     body:has(input[type='radio'][value='light']:checked) { color-scheme: light }
@@ -86,7 +77,7 @@
     content: counters(numsection, ".") ") ";
   }
 
-  .inmemoriam {
+  .former {
     font-style: italic;
   }
   </style>

--- a/spec/index.html
+++ b/spec/index.html
@@ -40,7 +40,7 @@
         { name: "Markus Lanthaler", note: "RDF 1.1" },
         { name: "Graham Klyne", note: "RDF 1.0" },
         { name: "Jeremy J. Carroll", note: "RDF 1.0" },
-        { name: "Brian McBride", note: "RDF 1.0" }
+        { name: "Brian McBride", note: "RDF 1.0, Chair" }
       ],
 
       xref: ["I18N-GLOSSARY", "INFRA"],

--- a/spec/index.html
+++ b/spec/index.html
@@ -22,17 +22,22 @@
       editors:  [
         { name: "Olaf Hartig", w3cid: "112469"},
         { name: "Pierre-Antoine Champin", w3cid: "129656"},
-        { name: "Gregg Kellogg", w3cid: "44770" },
         { name: "Andy Seaborne", w3cid: "29909" }
       ],
 
       formerEditors: [
-        { name: "Richard Cyganiak" },
-        { name: "David Wood", note: "Chair" },
-        { name: "Markus Lanthaler" },
-        { name: "Graham Klyne" },
-        { name: "Jeremy J. Carroll" },
-        { name: "Brian McBride" }
+        {
+          name: "Gregg Kellogg",
+          retiredDate: "2025-09-06",
+          extras: [{name: "in memoriam", class: "inmemoriam"}],
+
+        },
+        { name: "Richard Cyganiak", note: "RDF 1.1" },
+        { name: "David Wood", note: "RDF 1.1, Chair" },
+        { name: "Markus Lanthaler", note: "RDF 1.1" },
+        { name: "Graham Klyne", note: "RDF 1.0" },
+        { name: "Jeremy J. Carroll", note: "RDF 1.0" },
+        { name: "Brian McBride", note: "RDF 1.0" }
       ],
 
       xref: ["I18N-GLOSSARY", "INFRA"],
@@ -67,6 +72,12 @@
     font-weight: bold;
     counter-increment: numsection;
     content: counters(numsection, ".") ") ";
+  }
+
+  .inmemoriam {
+    font-style: italic;
+    display: inline-block;
+    margin-bottom: 0.8em;
   }
   </style>
   <!-- Link CSS used by SVGs, to make Echidna discover and bundle it. -->

--- a/spec/index.html
+++ b/spec/index.html
@@ -46,7 +46,19 @@
       doJsonLd:     true,
       wgPublicList: "public-rdf-star-wg",
       maxTocLevel: 2,
+      postProcess: [moveGreggAsLeadEditor],
     };
+
+    function moveGreggAsLeadEditor(config, doc, utils) {
+      const dl = doc.querySelector(".head details dl");
+      const editors = dl.querySelector("dt:nth-of-type(6)");
+      const gregg = dl.querySelector("dt:nth-of-type(7) + dd");
+      dl.removeChild(gregg);
+      const leadEditor = editors.cloneNode();
+      leadEditor.innerText = "Lead Editor";
+      dl.insertBefore(leadEditor, editors);
+      dl.insertBefore(gregg, editors);
+    }
   </script>
   <style>
     body:has(input[type='radio'][value='light']:checked) { color-scheme: light }
@@ -76,8 +88,6 @@
 
   .inmemoriam {
     font-style: italic;
-    display: inline-block;
-    margin-bottom: 0.8em;
   }
   </style>
   <!-- Link CSS used by SVGs, to make Echidna discover and bundle it. -->


### PR DESCRIPTION
the W3C automated process requires all editors to be active W3C members;
we discussed with the chairs and other co-editors and this solution was proposed.

@domel I'm requesting your review in view of applying the same to N-Triples and other concrete syntaxes


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/247.html" title="Last updated on Oct 7, 2025, 12:16 PM UTC (5f0724f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/247/83186bd...5f0724f.html" title="Last updated on Oct 7, 2025, 12:16 PM UTC (5f0724f)">Diff</a>