### PR TITLE
2025 iherman review

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -883,6 +883,11 @@ Accept: text/turtle; version=1.2
 
     <p>The three components (|s|, |p|, |o|) of an [=RDF triple=] are respectively called the <dfn class=export >subject</dfn>, <dfn class=export >predicate</dfn> and <dfn class=export >object</dfn> of the triple.</p>
 
+    <p class="note">The definition of <a>triple</a> is recursive.
+      That is, a <a>triple</a> can itself have an
+      <a>object</a> component which is another <a>triple</a>.
+      However, by this definition, cycles of <a>triples</a> cannot be created.</p>
+
     <p>The set of <span id="dfn-rdf-node"></span><span id="dfn-nodes"></span><dfn id="dfn-node" class="export" data-lt="RDF node">nodes</dfn> of an <a>RDF graph</a>
       is the set of <a>subjects</a> and <a>objects</a> of the <a>asserted triples</a> of the graph.
       It is possible for a [=predicate=] [=IRI=] to also occur as a [=node=] in
@@ -898,11 +903,6 @@ Accept: text/turtle; version=1.2
       <li>|o| and <var>o'</var> are [=RDF term equality|equal=].</li>
     </ul>
 
-
-    <p class="note">The definition of <a>triple</a> is recursive.
-      That is, a <a>triple</a> can itself have an
-      <a>object</a> component which is another <a>triple</a>.
-      However, by this definition, cycles of <a>triples</a> cannot be created.</p>
   </section>
 
   <section id="section-terms">


### PR DESCRIPTION
fixing two comments made by @iherman in a private conversation.

Besides the missing colon, the main change is to move the note about "triples can not form cycles" closer to the definition of cycles.

Currently people could read the word "this definition" in the note as referring to the definition just above the note, i.e. the definition of "term equality". This is inaccurate and confusing. Moving the note closer to the definition of "triple" aims to clarify that.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/249.html" title="Last updated on Oct 16, 2025, 11:34 AM UTC (06524df)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/249/1b34ef0...06524df.html" title="Last updated on Oct 16, 2025, 11:34 AM UTC (06524df)">Diff</a>