### PR TITLE
remove normative dependency to Semantics

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -2052,7 +2052,7 @@ Accept: text/turtle; version=1.2
     unique IRI (a <dfn class="export">Skolem IRI</dfn>) for each blank node so replaced.</p>
 
   <p>This transformation produces a new graph which entails the original one
-    (see also <a data-cite="RDF12-SEMANTICS#skolemization">Skolemization</a>).
+    <span class=informative>(see also <a data-cite="RDF12-SEMANTICS#skolemization">Skolemization</a>)</span>.
     In this context it is important to note that Skolem IRIs and blank nodes are
     different in nature: while IRIs directly denote resources, blank nodes only indicate 
     the existence of a resource. By producing Skolem IRIs, we create concrete witnesses of this existence.    


### PR DESCRIPTION
RDF 1.2 Semantics depends on RDF 1.2 Concept, there should be no cycle. This link to RDF 1.2 Semantics is informative (it is merely a "see also"), so I marked the parenthesis with class 'informative', which fixes the issue.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/251.html" title="Last updated on Oct 20, 2025, 9:29 AM UTC (904d47c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/251/1b34ef0...904d47c.html" title="Last updated on Oct 20, 2025, 9:29 AM UTC (904d47c)">Diff</a>