### PR TITLE
RDF Reference IRI

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1038,7 +1038,7 @@ Accept: text/turtle; version=1.2
       </p>
       <p>
         An <dfn data-lt="RDF reference">RDF Reference IRI</dfn>,
-        sometimes just called <a>RDF Reference</a>,
+        sometimes called simply <a>RDF Reference</a>,
         is an <a>IRI</a> that is suitable for use as a global reference.
       </p>
       


### PR DESCRIPTION
This closes #223.
This closes #169 by referring to the `irelative-iri` production of the IRI grammar.

Add an informative section about minting IRIs, with defined terminology `RDF Reference IRI` for IRIs suitable for use in published RDF. The basic syntax of IRIs (RFC3986/7) is for other uses of IRIs and is too broad (e.g. `http:abcd`).

The section is "informative" because advice can not be checked or enforced when consuming published RDF. For example, the data consumer can not be assumed to know URI scheme rules.

Changes are in section 3.3.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/255.html" title="Last updated on Nov 3, 2025, 4:42 PM UTC (64634ac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/255/c9c542d...64634ac.html" title="Last updated on Nov 3, 2025, 4:42 PM UTC (64634ac)">Diff</a>