### PR TITLE
Remove editor's note about conformance levels

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -746,10 +746,6 @@ Accept: text/turtle; version=1.2
       with <a>triples</a> that only contain <a>basic RDF terms</a> &mdash; i.e.,
       they do not contain <a>triple terms</a>.</li>
   </ul>
-  <p class="ednote">The conformance levels described above are tentative,
-    and still the subject of group discussion. An alternative to conformance
-    levels, "profiles", may be adopted instead, abandoned, or described in 
-    another specification.</p>
 
   <section id="defined-version-labels">
     <h3>Version Labels</h3>


### PR DESCRIPTION
As noted in the [telecon of 2025-11-13](https://www.w3.org/2025/11/13-rdf-star-minutes.html#9253), this is no longer an active subject of discussion within the working group. 

This PR removes the editor's note that "conformance" terminology was tentative.

See #248.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/256.html" title="Last updated on Nov 13, 2025, 6:04 PM UTC (1b941d2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/256/2928736...1b941d2.html" title="Last updated on Nov 13, 2025, 6:04 PM UTC (1b941d2)">Diff</a>