### PR TITLE
Mark Content-Type with the code element

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -686,7 +686,7 @@ For example, the term <code>:Alice</code> from a [=triple term=] and <code>:Alic
       are encouraged to announce their version (i.e., for RDF documents that do not make use
       of RDF 1.2-specific functionality it is discouraged to announce a version).</p>
 
-    <p>To announce the version in the HTTP responses using the Content-Type header,
+    <p>To announce the version in the HTTP responses using the <code>Content-Type</code> header,
       the server is expected to use the <code>version</code> parameter,
       as illustrated in the following example response.</p>
 
@@ -2338,7 +2338,7 @@ Accept: text/turtle; version=1.2
 
   <ul>
     <li>Added <a href="#section-version-announcement" class="sectionRef"></a>
-      for announcing RDF versions in RDF documents via the HTTP Content-Type header and/or syntax.</li>
+      for announcing RDF versions in RDF documents via the HTTP <code>Content-Type</code> header and/or syntax.</li>
     <li>Added <a href="#section-dataset-quad" class="sectionRef"></a>
       for informative definition of a <a>quad</a>.</li>
    <li>Added <a href="#section-triple-terms-reification" class="sectionRef"></a>


### PR DESCRIPTION
This PR is a [class 1](https://www.w3.org/policies/process/#class-1) change marking `Content-Type` with `<code>Content-Type</code>`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/csarven/rdf-concepts/pull/257.html" title="Last updated on Dec 1, 2025, 10:26 AM UTC (f6d0acf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/257/39e660b...csarven:f6d0acf.html" title="Last updated on Dec 1, 2025, 10:26 AM UTC (f6d0acf)">Diff</a>