### PR TITLE
Reference test cases

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -15,6 +15,9 @@
       shortName:            "rdf12-concepts",
       copyrightStart:       "2004",
 
+      implementationReportURI: "https://w3c.github.io/rdf-tests/rdf/rdf12/reports/",
+      testSuiteURI:            "https://w3c.github.io/rdf-tests/rdf/rdf12/",
+
       previousPublishDate:  "2014-02-25",
       previousMaturity:     "REC",
       prevRecShortname:     "rdf11-concepts",


### PR DESCRIPTION
We need to decide whether we need a "RDF 1.2 Test Cases document" similar to NOTE [RDF 1.1 Test Cases document](https://www.w3.org/TR/2014/NOTE-rdf11-testcases-20140225/) or whether some text in RDF Concepts is sufficient.

The other RDF 1.2 documents have a test suite link in their document details.

* Part of #248.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/258.html" title="Last updated on Dec 14, 2025, 5:45 PM UTC (93b917a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/258/39e660b...93b917a.html" title="Last updated on Dec 14, 2025, 5:45 PM UTC (93b917a)">Diff</a>