### PR TITLE
cite 'basic encoding' from RDF-INTEROP

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -792,8 +792,8 @@ Accept: text/turtle; version=1.2
 
       <ol>
         <li>Eliminate <a>triple terms</a> by using an algorithm such
-          as <em>Unstar</em> (downgrading from version "1.2" to "1.2-basic" or to "1.1").
-          <div class="ednote">Fix this when such an algorithmm is defined.</div></li>
+          as <i>basic encoding</i> as defined in [[RDF-INTEROP]] (downgrading from version "1.2" to "1.2-basic").
+          </li>
         <li>Replace <a>directional language-tagged strings</a>
           by <a>literals</a> with a <a>datatype IRI</a> that
           uses the <a data-cite="JSON-LD11#the-i18n-namespace">`i18n` namespace</a>, as defined in [[JSON-LD11]]


### PR DESCRIPTION
partially resolve #248

NB: RDF-INTEROP is not published yet, but should be soon


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/260.html" title="Last updated on Dec 12, 2025, 8:37 AM UTC (a3c3cdb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/260/bc69779...a3c3cdb.html" title="Last updated on Dec 12, 2025, 8:37 AM UTC (a3c3cdb)">Diff</a>