### PR TITLE
improve discussion on text direction - fix #262

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1263,7 +1263,7 @@ Accept: text/turtle; version=1.2
         but this is not always sufficient to correctly render bidirectional text.
 
       <p>
-        Consider the arabic translation of the book title "HTML and CSS: Designing Websites".
+        Consider the Arabic translation of the book title "HTML and CSS: Designing Websites".
         In a left-to-right context (such as an English web page),
         with proper [=bidi isolation=] but <em>without</em> an explicit base direction,
         it would be incorrectly displayed as follows:
@@ -1281,16 +1281,16 @@ Accept: text/turtle; version=1.2
       <p>
         Note that the language and base direction address string external bidirectional issues,
         related to correctly displaying the string in context
-        (e.g. avoiding <a href="https://www.w3.org/TR/i18n-glossary/#dfn-spillover-effects">spillover</a>
-        problems). It does not address string internal directional issues,
-        which may occurr in more complex examples, such as the following:
+        (e.g., avoiding <a href="https://www.w3.org/TR/i18n-glossary/#dfn-spillover-effects">spillover</a>
+        problems). It does not address directional issues internal to the string,
+        which may occur in more complex examples, such as the following:
       </p>
-      <p class=example dir="ltr">&quot;<bdi dir="rtl" lang="ar">HTML و CSS: تصميم مواقع الويب</bdi>&quot; is the arabic title of the book.</p>
+      <p class=example dir="ltr">&quot;<bdi dir="rtl" lang="ar">HTML و CSS: تصميم مواقع الويب</bdi>&quot; is the Arabic title of the book.</p>
 
       <p>
         A [=directional language-tagged string=]
         representing that example will have the language tag `en` and the base direction `ltr`,
-        but also requires specific Unicode control characters to mark the text between the quotes as `rtl`.
+        but also requires specific Unicode bidirectional formatting characters to isolate and mark the text between the quotes as `rtl`.
       </p>
 
       <div class=note>


### PR DESCRIPTION
I changed the example, because the one that was provided was actually working even without an explicit base direction(the first strongly directional character was providing the right hint).

The new example is more tricky and works only when the base direction is explicitly provided.

To respond to #262 I added a second, even more complex example. Following the recommendations at [1], I presented the use of datatypes rdf:HTML or rdf:XMLLiteral as best practices, and suggested the use of Unicode control character as a fallback.

[1] https://www.w3.org/International/questions/qa-bidi-controls


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/265.html" title="Last updated on Mar 27, 2026, 9:16 AM UTC (7dd16f4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/265/bc69779...7dd16f4.html" title="Last updated on Mar 27, 2026, 9:16 AM UTC (7dd16f4)">Diff</a>