### PR TITLE
mark references as non-normative

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -793,11 +793,11 @@ Accept: text/turtle; version=1.2
       Data conforming to version "1.1" is valid as data with version "1.2-basic", 
       and data conforming to version "1.2-basic" is valid as data with version "1.2".
       Data conforming to version "1.1" has the same semantics 
-      under [[[RDF11-MT]]] and under [[[RDF12-SEMANTICS]]].
+      under [[[?RDF11-MT]]] and under [[[?RDF12-SEMANTICS]]].
     </p>
 
     <p>
-      See [[[RDF-INTEROP]]] for details of encoding "1.2" as "1.2-basic".
+      See [[[?RDF-INTEROP]]] for details of encoding "1.2" as "1.2-basic".
     </p>
 
     <p>


### PR DESCRIPTION
they appear in a normative section, so were automatically tagged as normative. However, RDF12-SEMANTICS should depend on RDF12-CONCEPTS, not the opposite. Furthermore, RDF12-CONCEPTS should not depend on the (non-normative) RDF12-INTEROP note.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/267.html" title="Last updated on Jan 20, 2026, 5:14 PM UTC (2fece36)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/267/987abfa...2fece36.html" title="Last updated on Jan 20, 2026, 5:14 PM UTC (2fece36)">Diff</a>