### PR TITLE
GH-268: Some URI schemes are not path-hierarchical

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1067,13 +1067,15 @@ Accept: text/turtle; version=1.2
         <strong>Reference Resolution:</strong>
         An <a>RDF Reference IRI</a> is unchanged by
         <a data-cite="RFC3986#section-5">reference resolution</a>. 
-        In URI schemes such as `http` and `https`,
-        the
+        In URI schemes such as `http` and `https`, the
         <a data-cite="RFC3986#section-3.3">path component</a>
         is part of the hierarchy visible to the 
         resolution algorithm. When resolved, the
         <a data-cite="RFC3986#section-3.3">path component</a> 
         starts with a `/` character and does not contain `.` or `..` segments.
+        For example, `https://example/data` resolved against any base IRI
+        is `https://example/data` (unchanged), whereas `https://example/path/../data` 
+        resolved against an arbitrary base IRI is `https://example.com/data`.
       </p>
       <p>
         <strong>Relative IRI references:</strong>


### PR DESCRIPTION
Closes #268.

Expand on when to resolve IRIs - path resolution is scheme dependent.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/269.html" title="Last updated on Feb 27, 2026, 10:02 PM UTC (3a79789)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/269/3c34d7a...3a79789.html" title="Last updated on Feb 27, 2026, 10:02 PM UTC (3a79789)">Diff</a>