### PR TITLE
Remove Location HTTP header from version example

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -705,7 +705,6 @@ For example, the term <code>:Alice</code> from a [=triple term=] and <code>:Alic
 
     <pre class="box http">HTTP/1.1 200 OK
 Content-Type: text/turtle; version=1.2
-Location: http://example.com/document.ttl
     </pre>
 
     <p>Servers are also expected to announce the version in-line,


### PR DESCRIPTION
This is just a correction of an error in the example; [`Location`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Location) is used for `3XX` redirect responses and `301 Created`, whereas [`Content-Location`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Location) for `200 OK` (to provide location of content; i.e. concrete representation being served.)

There is a wider issue: https://github.com/w3c/rdf-star-wg/issues/189, about where and how this should be elaborated upon.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/pull/276.html" title="Last updated on Apr 23, 2026, 5:11 PM UTC (531c8d4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-concepts/276/e0d243b...531c8d4.html" title="Last updated on Apr 23, 2026, 5:11 PM UTC (531c8d4)">Diff</a>